### PR TITLE
다른 문서 간에 문단 복사-붙여넣기 기능에 수식 컨트롤 복사 기능 추가

### DIFF
--- a/src/main/java/kr/dogfoot/hwplib/object/bodytext/paragraph/text/HWPCharControlExtend.java
+++ b/src/main/java/kr/dogfoot/hwplib/object/bodytext/paragraph/text/HWPCharControlExtend.java
@@ -118,6 +118,18 @@ public class HWPCharControlExtend extends HWPChar {
         return false;
     }
 
+    public boolean isEquation() {
+        if (getCode() == 0x000b
+                && addition != null
+                && addition[3] == 'e'
+                && addition[2] == 'q'
+                && addition[1] == 'e'
+                && addition[0] == 'd') {
+            return true;
+        }
+        return false;
+    }
+
     public boolean isHyperlinkStart() {
         if (getCode() == 0x0003
                 && addition != null

--- a/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParaTextCopier.java
+++ b/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParaTextCopier.java
@@ -24,7 +24,8 @@ public class ParaTextCopier {
                     break;
                 case ControlExtend:
                     if (((HWPCharControlExtend) hwpChar).isTable() ||
-                            ((HWPCharControlExtend) hwpChar).isGSO()) {
+                            ((HWPCharControlExtend) hwpChar).isGSO() ||
+                            ((HWPCharControlExtend) hwpChar).isEquation()) {
                         copyExtendChar((HWPCharControlExtend) hwpChar, target.addNewExtendControlChar());
                     } else {
                         notCopiedCharacterSize += 8;

--- a/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParagraphCopier.java
+++ b/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParagraphCopier.java
@@ -1,11 +1,13 @@
 package kr.dogfoot.hwplib.tool.paragraphadder;
 
 import kr.dogfoot.hwplib.object.bodytext.control.Control;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlEquation;
 import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
 import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
 import kr.dogfoot.hwplib.object.bodytext.control.gso.GsoControl;
 import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
 import kr.dogfoot.hwplib.object.bodytext.paragraph.ParagraphList;
+import kr.dogfoot.hwplib.tool.paragraphadder.control.EquationCopier;
 import kr.dogfoot.hwplib.tool.paragraphadder.control.GsoCopier;
 import kr.dogfoot.hwplib.tool.paragraphadder.control.TableCopier;
 import kr.dogfoot.hwplib.tool.paragraphadder.docinfo.DocInfoAdder;
@@ -95,6 +97,7 @@ public class ParagraphCopier {
                     GsoCopier.copy((GsoControl) c, (GsoControl) target.addNewGsoControl(((GsoControl) c).getGsoType()), docInfoAdder);
                     break;
                 case Equation:
+                    EquationCopier.copy((ControlEquation) c, (ControlEquation) target.addNewControl(ControlType.Equation), docInfoAdder);
                     break;
                 case SectionDefine:
                     break;

--- a/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParagraphMerger.java
+++ b/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParagraphMerger.java
@@ -1,6 +1,7 @@
 package kr.dogfoot.hwplib.tool.paragraphadder;
 
 import kr.dogfoot.hwplib.object.bodytext.control.Control;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlEquation;
 import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
 import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
 import kr.dogfoot.hwplib.object.bodytext.control.gso.GsoControl;
@@ -8,6 +9,7 @@ import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
 import kr.dogfoot.hwplib.object.bodytext.paragraph.charshape.CharPositionShapeIdPair;
 import kr.dogfoot.hwplib.object.bodytext.paragraph.text.HWPChar;
 import kr.dogfoot.hwplib.object.bodytext.paragraph.text.HWPCharType;
+import kr.dogfoot.hwplib.tool.paragraphadder.control.EquationCopier;
 import kr.dogfoot.hwplib.tool.paragraphadder.control.GsoCopier;
 import kr.dogfoot.hwplib.tool.paragraphadder.control.TableCopier;
 import kr.dogfoot.hwplib.tool.paragraphadder.docinfo.DocInfoAdder;
@@ -73,9 +75,10 @@ public class ParagraphMerger {
                 case ColumnDefine:
                     hasColumnDefine = true;
                     break;
-                    /*
                 case Equation:
+                    EquationCopier.copy((ControlEquation) c, (ControlEquation) target.addNewControl(ControlType.Equation), docInfoAdder);
                     break;
+                    /*
                 case Header:
                     break;
                 case Footer:

--- a/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/control/EquationCopier.java
+++ b/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/control/EquationCopier.java
@@ -1,0 +1,48 @@
+package kr.dogfoot.hwplib.tool.paragraphadder.control;
+
+import kr.dogfoot.hwplib.object.bodytext.control.ControlEquation;
+import kr.dogfoot.hwplib.object.bodytext.control.ctrlheader.CtrlHeaderGso;
+import kr.dogfoot.hwplib.object.bodytext.control.equation.EQEdit;
+import kr.dogfoot.hwplib.tool.paragraphadder.docinfo.DocInfoAdder;
+
+public class EquationCopier {
+    public static void copy(ControlEquation source, ControlEquation target, DocInfoAdder docInfoAdder) {
+        header(source.getHeader(), target.getHeader());
+        caption(source, target, docInfoAdder);
+        eqEdit(source.getEQEdit(), target.getEQEdit(), docInfoAdder);
+    }
+
+    private static void header(CtrlHeaderGso source, CtrlHeaderGso target) {
+        target.getProperty().setValue(source.getProperty().getValue());
+        target.setyOffset(source.getyOffset());
+        target.setxOffset(source.getxOffset());
+        target.setWidth(source.getWidth());
+        target.setHeight(source.getHeight());
+        target.setzOrder(source.getzOrder());
+        target.setOutterMarginLeft(source.getOutterMarginLeft());
+        target.setOutterMarginRight(source.getOutterMarginRight());
+        target.setOutterMarginTop(source.getOutterMarginTop());
+        target.setOutterMarginBottom(source.getOutterMarginBottom());
+        target.setInstanceId(source.getInstanceId());
+        target.setPreventPageDivide(source.isPreventPageDivide());
+        target.setExplanation(source.getExplanation());
+    }
+
+    private static void caption(ControlEquation source, ControlEquation target, DocInfoAdder docInfoAdder) {
+        if (source.getCaption() != null) {
+            target.createCaption();
+            CaptionCopier.copy(source.getCaption(), target.getCaption(), docInfoAdder);
+        }
+    }
+
+    private static void eqEdit(EQEdit source, EQEdit target, DocInfoAdder docInfoAdder) {
+        target.setProperty(source.getProperty());
+        target.setScript(source.getScript());
+        target.setLetterSize(source.getLetterSize());
+        target.getLetterColor().setValue(source.getLetterColor().getValue());
+        target.setBaseLine(source.getBaseLine());
+        target.setUnknown(source.getUnknown());
+        target.setVersionInfo(source.getVersionInfo());
+        target.setFontName(source.getFontName());
+    }
+}


### PR DESCRIPTION
수식(equation)을 복사하는 EquationCopier 객체를 만들었습니다.
ParagraphCopier와 ParagraphMerger에서 ControlEquation과 ControlExtend text를 복사할 수 있도록 하였습니다.

수정해야할 부분이 필요하다면 말씀해주시면 감사하겠습니다.