### PR TITLE
다중문단으로 입력된 필드 텍스트 설정 문제 수정

### DIFF
--- a/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParaTextSetter.java
+++ b/src/main/java/kr/dogfoot/hwplib/tool/paragraphadder/ParaTextSetter.java
@@ -67,7 +67,7 @@ public class ParaTextSetter {
                 continue;
             } else if (cpsip.getPosition() >= startIndex && cpsip.getPosition() <= endIndex) {
                 deleteItems.add(cpsip);
-            } else if (cpsip.getPosition() < endIndex) {
+            } else if (cpsip.getPosition() > endIndex) {
                 int oldLen = endIndex - startIndex + 1;
                 cpsip.setPosition(cpsip.getPosition() + oldLen - len);
             }


### PR DESCRIPTION
공개해주신 라이브러리에 많은 신세 지고 있습니다. 감사합니다.

다름이 아니라 사용 중 아래와 같은 증상이 있어 수정해봤습니다.

- 증상:
같은이름의 field가 여러개 존재하고, 필드가 다중문단으로 구성되어 있을 경우(미리 값을 입력해놨을때)
두번째 field부터는 텍스트가 변경되지 않음

- 원인:
한번에 field position을 전부 찾아놓고 텍스트를 변경하면서
찾아놨던 field position이 실제 문서상의 텍스트 위치와 달라지기 때문에
두번째 field부터는 end position을 찾지 못함.

 텍스트를 변경 후 다음 field position을 새로 찾는 방법으로 처리함.