### PR TITLE
non-BMP 문자(서러게이트 쌍)가 U+FFFD로 깨지는 문제 수정

### DIFF
--- a/src/main/java/kr/dogfoot/hwplib/object/bodytext/paragraph/text/HWPCharNormal.java
+++ b/src/main/java/kr/dogfoot/hwplib/object/bodytext/paragraph/text/HWPCharNormal.java
@@ -1,7 +1,6 @@
 package kr.dogfoot.hwplib.object.bodytext.paragraph.text;
 
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 
 /**
  * 일반 Character
@@ -46,10 +45,12 @@ public class HWPCharNormal extends HWPChar {
      * @return 변환된 문자열
      */
     private String intToString(int code) {
-        byte[] ch = new byte[2];
-        ch[0] = (byte) (code & 0xff);
-        ch[1] = (byte) ((code >> 8) & 0xff);
-        return new String(ch, 0, 2, StandardCharsets.UTF_16LE);
+        // 2 byte 문자코드를 그대로 보존한다. UTF-16 서러게이트 쌍(보충 평면 문자)은
+        // 두 개의 HWPCharNormal에 나뉘어 저장되는데, 각 2 byte를 따로 UTF-16LE로
+        // 디코딩하면 외톨이 서러게이트가 U+FFFD로 바뀐다. 코드 단위를 그대로 두면
+        // getCh()를 이어붙이는 StringBuilder에서 서러게이트 쌍이 올바른 코드 포인트로
+        // 다시 합쳐진다.
+        return String.valueOf((char) code);
     }
 
     public HWPChar clone() {


### PR DESCRIPTION
## 문제

`HWPCharNormal.intToString()`이 글자별 2 byte 문자코드를 **개별적으로** UTF-16LE로 디코딩합니다.

```java
byte[] ch = new byte[2];
ch[0] = (byte) (code & 0xff);
ch[1] = (byte) ((code >> 8) & 0xff);
return new String(ch, 0, 2, StandardCharsets.UTF_16LE);
```

보충 평면(non-BMP) 문자는 UTF-16 **서러게이트 쌍**으로 인코딩되어 **두 개의 `HWPCharNormal`** 에 나뉘어 저장됩니다. 각 반쪽을 따로 디코딩하면 외톨이 서러게이트가 되어 `new String(..., UTF_16LE)`가 이를 `U+FFFD`(대체 문자)로 바꿉니다.

**증상 예시:** 한컴 사용자영역(PUA)의 겹낫표 `『`(U+F0854) / `』`(U+F0855)가 변환·추출 시 `◆◆`(`U+FFFD U+FFFD`)로 깨집니다. `TextExtractor` 결과에서도 동일하게 재현됩니다.

## 수정

코드 단위를 그대로 보존합니다.

```java
return String.valueOf((char) code);
```

서러게이트 반쪽이 그대로 유지되므로, `getCh()`의 반환값을 이어붙이는 `StringBuilder`(`TextExtractor`, hwp2hwpx의 `ForChars` 등)에서 서러게이트 쌍이 올바른 코드 포인트로 다시 합쳐집니다. BMP 문자에 대해서는 기존 동작과 완전히 동일합니다(2 byte 값 → 동일 char).

미사용이 된 `import java.nio.charset.StandardCharsets;` 도 함께 제거했습니다.

## 검증

실제 HWP 문서를 HWPX로 변환했을 때:

- 수정 전: `『 … 』` → `◆◆ … ◆◆` (U+FFFD 6개)
- 수정 후: `U+F0854 … U+F0855` 보존, 한컴 정품(한글 작성) HWPX와 **바이트 단위로 일치**

BMP 특수문자(예: 반각 낫표 `｢｣` U+FF62/63)는 수정 전후 모두 정상이며 영향받지 않습니다.
