### PR TITLE
feat: HWP 3.x(레거시 바이너리) 및 HWPML 3.0 읽기 지원 추가 + JDK 17 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Maven build output
+target/
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
+
+# Compiled class files
+*.class
+
+# Logs
+*.log
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Local-only assets (kept out of git history)
+docs/spec/
+src/test/resources/sample-docs/

--- a/docs/hwp3-hwpml-support-plan.md
+++ b/docs/hwp3-hwpml-support-plan.md
@@ -1,0 +1,309 @@
+# hwplib HWP 3.x(레거시 바이너리) · HWPML 3.0 지원 계획서
+
+- 작성일: 2026-06-02
+- 대상 저장소: hwplib (v1.1.10)
+- 참조 규격: 한컴 「한글 문서 파일 형식 3.0 / HWPML」 revision 1.2 (20141105)
+  - 로컬 사본: `docs/spec/hwpml3.0_rev1.2.pdf`
+  - Part I (p.3~46): 한글 3.x 문서 파일 구조 (Hwp Document File Format 3.x)
+  - Part II (p.47~110): HWPML 구조
+
+---
+
+## 1. 목표 및 확정 범위
+
+| 항목 | 결정 |
+|------|------|
+| 대상 포맷 | **둘 다** — ① 레거시 바이너리 HWP 3.x ② HWPML 3.0 (XML) |
+| 지원 범위 | **전체 읽기(구조 보존)** — 텍스트 추출만이 아니라 서식·표·이미지·그리기 개체까지 객체 모델로 파싱 |
+| 쓰기(저장) | **범위 외** (이번 계획에서 제외) |
+| 호환 대상 | 한글 3.0 / 97 / 2002~2010이 생성한 3.x·HWPML 파일 |
+
+설계 원칙(글로벌 지침 반영):
+- **순수 추가 방식**: 기존 HWP5 읽기 경로(`HWPReader`, `CompoundFileReader`, 객체 모델)는 수정하지 않는다. 새 패키지만 추가하므로 기존 기능 회귀 위험이 없다(백업 불필요).
+- **핵심 기능 / 보조 기능 구분**: 본문/문단/글자/서식 파싱은 핵심. 그리기 개체·OLE·미리보기 이미지 등은 보조이며, 보조 기능 착수 전 사용자 확인.
+
+---
+
+## 2. 현재 아키텍처 제약 (조사 결과)
+
+- `kr.dogfoot.hwplib.object.HWPFile` = HWP 5.0 전용 모델
+  - `FileHeader` / `DocInfo` / `BodyText` / `BinData` / `SummaryInformation` / `Scripts`
+  - `BodyText` → `Section[]` → `Paragraph[]` → (글자/컨트롤/글자모양…)
+- `kr.dogfoot.hwplib.reader.HWPReader`
+  - 모든 진입점(`fromFile`, `fromInputStream`, `fromURL`, `fromBase64String`)이 `CompoundFileReader`(OLE/CFB)에 직접 결합.
+  - record header + tagID 기반 스트림 파싱(HWP5 고유).
+- 결론: HWP 3.x·HWPML은 이 경로를 **재사용할 수 없고**, 별도 리더가 동일한 `HWPFile`(또는 변환 가능한) 객체를 산출하도록 해야 한다.
+
+---
+
+## 3. 핵심 설계 결정 — 객체 모델 타깃팅 전략
+
+다운스트림 도구(`tool/textextractor`, `objectfinder` 등)를 재사용하려면 최종 산출물이 기존 `HWPFile`이어야 한다. 그러나 포맷별 충실도가 달라 다음 **하이브리드 전략**을 권장한다.
+
+### 3.1 HWPML 3.0 → `HWPFile`로 직접 매핑
+- HWPML은 의미상 HWP 5.0과 사실상 동형(Header≈DocInfo, Body≈BodyText/Section). XML 엘리먼트를 기존 객체 모델 필드에 직접 채우는 것이 자연스럽다.
+- 산출물: 기존 `HWPFile` 그대로 → 모든 다운스트림 도구 즉시 호환.
+
+### 3.2 레거시 HWP 3.x → 전용 모델 + 변환기
+- HWP 3.x는 구조가 HWP5와 크게 다르다(평면 record, `hchar` 내부코드, 단·페이지 힌트, 정보블록 #0/#1/#2 등). HWP5 record 모델에 직접 욱여넣으면 손실·왜곡이 크다.
+- 권장: **충실한 전용 객체 모델** `object.hwp3.*` 를 먼저 만들고, **best-effort 변환기** `Hwp3ToHwpFileConverter`로 `HWPFile`을 부가 제공.
+  - 1차 목표(전용 모델로 완전 파싱) → 2차 목표(HWPFile 변환으로 도구 재사용).
+
+> ⚠️ 결정 필요 지점: HWP 3.x를 "전용 모델 + 변환기"(권장)로 갈지, "HWPFile 직접 매핑"으로 갈지. 권장안은 충실도·유지보수 측면에서 유리하나 코드량이 늘어난다. (§9 참조)
+
+### 3.3 포맷 자동 판별 (Dispatch) — 신규 통합 진입점
+새 통합 진입점 `kr.dogfoot.hwplib.HWPLibReader`(또는 기존 `HWPReader`에 정적 메서드 추가)를 두고 매직/내용으로 분기:
+
+| 시그니처 / 내용 | 포맷 | 라우팅 |
+|----------------|------|--------|
+| OLE CFB (`D0 CF 11 E0 …`) + "HWP Document File" | HWP 5.x | 기존 `HWPReader` |
+| `48 57 50 20 44 6F 63 75 6D 65 6E 74 20 46 69 6C 65 20 56 33 2E 30 30 …`(`HWP Document File V3.00 \x1a\1\2\3\4\5`) | HWP 3.x | 신규 `HWP3Reader` |
+| `<?xml … <HWPML …>` (또는 BOM 후 `<HWPML`) | HWPML | 신규 `HWPMLReader` |
+
+---
+
+## 4. 레거시 바이너리 HWP 3.x 리더 계획
+
+### 4.1 포맷 핵심 사실 (규격 Part I 기준)
+- **파일 인식 정보**: 첫 30바이트, 시그니처 `"HWP Document File V3.00 \x1a\1\2\3\4\5"`.
+- **자료형**: little-endian. `byte/sbyte/word/sword/dword/sdword`, 문자형 `hchar`(2B 한글 내부코드), `echar`(1B ASCII), `kchar`(1B 상용조합형), 크기단위 `hunit/shunit`(1/1800인치).
+- **전체 구조**(표 2):
+  1. 파일 인식 정보 (30B)
+  2. 문서 정보 (128B) — 압축 플래그·암호 여부 포함
+  3. 문서 요약 (1008B)
+  4. 정보 블록 #0 (가변)
+  5. 글꼴 이름 (가변, **압축**)
+  6. 스타일 (가변, **압축**)
+  7. 문단 리스트 (가변, **압축**)
+  8. 추가 정보 블록 #1 (가변, **압축**)
+  9. 추가 정보 블록 #2 (가변)
+- **압축**: `글꼴 이름`~`추가 정보 블록 #1`이 하나의 gzip 스트림으로 저장. 문서 정보의 압축 플래그 확인 후 `GZIPInputStream`/`Inflater`로 해제하여 비압축 파일처럼 처리.
+- **문자 인코딩**: `hchar`는 유니코드가 아니다 → **내부코드→유니코드 변환 테이블** 필요(조합형/확장완성형). 가장 큰 난제.
+- **세부 구조**: 문단(4장), 문단모양(5장), 글자모양(6장), 특수문자/필드코드(10장), 그리기 개체(11장), OLE(12장).
+
+### 4.2 패키지 설계
+```
+kr.dogfoot.hwplib.reader.hwp3            # 리더 (스트림/레코드 파서)
+  HWP3Reader.java                        # 진입점: fromFile/fromInputStream
+  ForFileRecognition.java                # 30B 인식정보 + 시그니처 검증
+  ForDocInfo3.java                        # 128B 문서정보(압축/암호 플래그)
+  ForDocSummary3.java                     # 1008B 문서요약
+  ForInfoBlock3.java                      # 정보블록 #0/#1/#2
+  ForFontNames3.java / ForStyles3.java
+  ForParagraphList3.java / ForParagraph3.java
+  ForParaShape3.java / ForCharShape3.java
+  ForSpecialChar3.java                    # 필드코드/표/그림/선/각주 등 (보조)
+  ForDrawingObject3.java / ForOle3.java   # (보조)
+kr.dogfoot.hwplib.object.hwp3.*          # 전용 객체 모델
+kr.dogfoot.hwplib.util.hwp3
+  Hwp3StreamReader.java                   # LE 리더 + gzip 해제 + hchar 디코딩
+  Hwp3CharCodeTable.java                  # 내부코드 ↔ 유니코드
+kr.dogfoot.hwplib.tool.hwp3conv
+  Hwp3ToHwpFileConverter.java             # HWP3 모델 → HWPFile (best-effort)
+```
+
+### 4.3 단계 (핵심 → 보조)
+- **C1 (핵심)**: 시그니처 검증 + 30/128/1008B 헤더 + gzip 해제 파이프라인 + `Hwp3StreamReader`.
+- **C2 (핵심)**: `hchar`→유니코드 변환 테이블, 글꼴 이름·스타일 파싱.
+- **C3 (핵심)**: 문단 리스트/문단/줄/글자모양/글자들 → 텍스트·기본서식 완전 파싱.
+- **C4 (보조, 사전확인)**: 특수문자/필드코드(표·각주·하이퍼링크·번호 등) 파싱.
+- **C5 (보조, 사전확인)**: 그리기 개체·OLE·미리보기 이미지.
+- **C6**: `Hwp3ToHwpFileConverter`로 HWPFile 변환 → 텍스트 추출기 재사용.
+
+---
+
+## 5. HWPML 3.0 리더 계획
+
+### 5.1 포맷 핵심 사실 (규격 Part II 기준)
+- 루트 `<HWPML>` → `<HEAD>`(문서요약/설정/글꼴·테두리·글자모양·탭·글머리표·문단모양·스타일/메모) + `<BODY>`(글자·구역정의·표·그림·그리기개체·양식객체·OLE·필드·책갈피·머리말꼬리말·각주미주 등).
+- 좌표/크기 단위와 속성값 표기는 규격 §2(기본 속성값 형식)에 정의 — 파서가 공통 파싱 유틸로 처리.
+- HWP5 객체 모델과 의미가 대응되므로 **직접 매핑** 가능.
+
+### 5.2 패키지 설계
+```
+kr.dogfoot.hwplib.reader.hwpml
+  HWPMLReader.java                 # 진입점: fromFile/fromInputStream
+  ForHead.java                     # <HEAD> → DocInfo 매핑
+  ForBody.java                     # <BODY> → BodyText/Section 매핑
+  ForCharShapeML / ForParaShapeML / ForFaceNameML / ...
+  ForTableML / ForPictureML / ForDrawingObjectML / ...   # (보조)
+kr.dogfoot.hwplib.util.hwpml
+  XmlReaderHelper.java             # StAX(XMLStreamReader) 기반 공통 파싱
+  HWPMLAttrParser.java             # 기본 속성값 형식(§2) 파싱
+```
+- 파서 기술: **StAX(`javax.xml.stream`)** 권장(대용량·스트리밍, 추가 의존성 없음). JDK 내장.
+
+### 5.3 단계 (핵심 → 보조)
+- **M1 (핵심)**: 루트/HEAD/BODY 골격 + 글자 엘리먼트 → 텍스트.
+- **M2 (핵심)**: 글꼴/글자모양/문단모양/스타일 → DocInfo, 구역/단 정의.
+- **M3 (보조, 사전확인)**: 표·그림·그리기 개체·OLE·양식 객체.
+- **M4 (보조, 사전확인)**: 필드/책갈피/머리말꼬리말/각주미주/찾아보기/덧말 등.
+
+---
+
+## 6. 단계별 로드맵 (마일스톤)
+
+| 단계 | 산출물 | 검증 기준 |
+|------|--------|-----------|
+| **P0 ✅완료** | 포맷 판별 dispatch + 골격 패키지/인터페이스 | 세 포맷 라우팅 (합성 8 + 실제 19파일 통과) |
+| **P1 🟢 M1·M2·M3완료** | HWPML 본문+HEAD+표+그리기/글상자 | 6종 전부 텍스트 **≥99.9%** (3종 100%), over-extraction 0 ✅ |
+| **P2 🟡 C1+C2완료** | HWP3 헤더·해제(C1) + hchar 디코더(C2) | 조합형→유니코드 실문서 검증 ✅ (문단/표 C3 잔여) |
+| P3 | HWP3→HWPFile 변환 + 텍스트추출기 통합 (C6) | 기존 `TextExtractor` 동작 |
+| P4 | 보조 기능: 표/그림/그리기/OLE (양 포맷, **사전확인 후**) | 구조 보존 검증 |
+| P5 | 문서화·README 갱신·회귀 테스트 | 전체 테스트 통과 |
+
+---
+
+## 7. 빌드/의존성 영향
+- 빌드: Maven, **Java 17 타깃**(2026-06-02 7→17 상향), Apache POI 내장(`kr.dogfoot.hwplib.org.apache.poi`).
+- HWP3 gzip: `java.util.zip` (JDK 내장, 추가 의존성 없음).
+- HWPML: StAX `javax.xml.stream` (JDK 내장).
+- → **신규 외부 의존성 없음**.
+
+### 7.1 JDK 17 베이스 전환 (완료)
+Java 7 타깃은 최신 JDK에서 빌드 불가(제거된 API 사용)하여 17로 상향했다.
+- `pom.xml`: `source/target` 7→17, deprecated `<compilerVersion>1.7>` 제거.
+- `reader/HWPReader.java`: `javax.xml.bind.DatatypeConverter`(Java 11에서 제거) → `java.util.Base64`(`getMimeDecoder`).
+- `writer/autosetter/ForDocInfo.java`: 미사용 `com.sun.jmx.snmp.agent` 임포트 제거.
+- 검증: `mvn clean compile` (JDK 17) 통과.
+
+---
+
+## 8. 테스트 전략
+- `src/test/resources`에 포맷별 샘플(3.x, HWPML, 5.0 회귀용) 확보 — *사용자가 실제 샘플 파일 제공 필요*.
+- 단위: 헤더/시그니처, gzip 해제, hchar 변환, XML 속성 파싱.
+- 통합: 동일 내용의 5.0 / 3.x / HWPML 문서 → 추출 텍스트·문단 수 동등성 비교(가능 범위).
+- 회귀: 기존 HWP5 테스트 전부 통과(기존 코드 무변경이므로 자동 보장).
+
+---
+
+## 9. 리스크 및 미해결 결정 사항
+1. **HWP3 객체 모델 전략** (§3.2): 전용 모델+변환기(권장) vs HWPFile 직접 매핑 — *결정 필요*.
+2. **hchar→유니코드 변환표**: 조합형/확장완성형 매핑 정확도가 텍스트 품질을 좌우. 검증된 테이블 확보 또는 이식 필요(리스크 高).
+3. **샘플 파일 확보**: 실제 3.x·HWPML 파일이 있어야 검증 가능 — *사용자 제공 요청*.
+4. **보조 기능 범위**: 그리기 개체·OLE·수식은 작업량이 크다. 핵심(텍스트·서식·표) 완료 후 필요성 재확인.
+5. **암호/압축 변형**: 3.x 암호화 문서는 1차 범위에서 제외 권장.
+
+---
+
+## 11. P0 구현 결과 (2026-06-02 완료)
+
+확정 사항: HWP3 = **전용 모델 + 변환기**, **핵심 우선**, JDK 17 베이스.
+
+추가된 파일(모두 신규, 기존 코드 무수정):
+| 파일 | 역할 |
+|------|------|
+| `reader/FileFormat.java` | 형식 열거형(HWP5/HWP3/HWPML/UNKNOWN) |
+| `reader/FormatDetector.java` | 앞부분 바이트로 형식 판별(OLE/HWP3 sig/XML, BOM·UTF-16 고려) |
+| `reader/HWPLibReader.java` | **통합 진입점** — 판별 후 라우팅, 공통 `HWPFile` 반환 |
+| `reader/hwp3/HWP3Reader.java` | HWP3 리더 골격 — 시그니처 검증까지(본문 P2) |
+| `reader/hwpml/HWPMLReader.java` | HWPML 리더 골격 — 루트 검증까지(본문 P1) |
+| `object/hwp3/HWP3File.java` | HWP3 전용 모델 골격(구조 주석/ TODO) |
+| `tool/hwp3conv/Hwp3ToHwpFileConverter.java` | HWP3→HWPFile 변환기 골격(P3) |
+| `src/test/sample/Detecting_FileFormat.java` | 사용 예제 |
+
+미구현 본문 파싱은 `UnsupportedOperationException("... not implemented yet (P0 skeleton)")`로 명시.
+
+## 12. P1 / M1 구현 결과 (2026-06-03)
+
+`reader/hwpml/HWPMLReader.java`에 StAX 기반 본문 파서 구현:
+- `<BODY>` → `<SECTION>` → `<P>` → `<TEXT CharShape>` → `<CHAR>` 순회 → `HWPFile`의
+  BodyText/Section/Paragraph/ParaText로 매핑.
+- 한 `<P>` 안의 여러 `<TEXT>/<CHAR>` 런을 한 문단으로 연결, 글자 모양 경계는 `ParaCharShape`에 best-effort 기록.
+- `<CHAR>` 끝의 pretty-print 줄바꿈 1개 제거(실제 텍스트와 정확히 일치 확인).
+- 보안: StAX DTD/외부 엔티티 비활성화(XXE 방지), `IS_COALESCING` 사용.
+- 컨트롤 컨테이너(TABLE/DRAWTEXT/HEADER/FOOTER/FOOTNOTE/ENDNOTE) 내부 중첩 문단은 M3까지 본문에서 제외.
+
+### 검증 (테스트 코퍼스)
+- `src/test/resources/sample-docs/` 에 동일 문서 6종 × {hwp5, hwp3, hwpml} + hwpx 1 + 배포용 hwp 1 (총 7.8MB).
+- 6종 모두 HWPML 본문 문단 텍스트가 HWP5 추출 결과와 **바이트 단위 동일**(문단 수·문자 수 일치, 최대 607문단/11,855자).
+
+## 13. P1 / M2 구현 결과 (2026-06-03)
+
+`reader/hwpml/ForHead.java` 신규 + `HWPMLReader` 통합: `<HEAD>`의 MAPPINGTABLE을 `DocInfo`로 매핑.
+- 글꼴(FONTFACE/FONT→7개 언어별 FaceName), 글자모양(CHARSHAPE: 크기·언어별 글꼴ID/비율/자간/장평/오프셋·굵게/기울임·색·테두리), 문단모양(PARASHAPE: 정렬·문단머리모양(HeadingType→ParaHeadShape)·머리id(Heading)·여백·탭), 번호정의(NUMBERING/PARAHEAD 레벨별 형식), 스타일(STYLE), 테두리·탭·글머리표(개수).
+- IDMappings 카운트 설정. 각 구역 첫 문단에 컨트롤 리스트 생성(`TextExtractor`의 구역 정의 참조 NPE 방지).
+
+### 검증
+- 6종 모두 `TextExtractor.extract()` **무오류 동작**(M1 단계의 NPE 해소).
+- 본문 문단 텍스트+문단머리 서식이 HWP5 추출과 일치. 3종은 HWPML 추출 라인이 HWP5의 부분집합으로 **완전 일치(CLEAN)**, 3종은 소수(1~9) 라인만 상이.
+- 상이 원인: ①표 셀 텍스트(HWP5는 포함, HWPML은 M3 전까지 제외) ②일부 아웃라인 문단머리 공백·인라인 컨트롤(각주/하이퍼링크, M3/M4). 내용 손상 아님.
+
+## 14. P1 / M3 (표) 구현 결과 (2026-06-03)
+
+`HWPMLReader`를 **재귀 하강(recursive-descent)** 방식으로 재작성 + 표 매핑:
+- `<TABLE>` → `ControlTable`(행/열/셀/셀 문단). 셀의 `<PARALIST>`→`<P>`를 재귀로 읽어 중첩 표·다단 문단 자연 처리.
+- 불변식 준수: ParaText의 ControlExtend 문자(0x0b "tbl ")와 문단 컨트롤 리스트를 1:1 순서로 추가(추출기 순차 인덱스 매칭).
+- 표 외 컨트롤(그림/그리기/글상자/각주)은 `skipSubtree`로 건너뜀(확장 문자/컨트롤 미생성 → 불변식 유지).
+
+### 검증 (문자 단위 커버리지, HWP5 추출 대비)
+| 문서 | 커버리지 |
+|------|---------|
+| 중소기업 융자계획(40,326자) | **100.00%** |
+| 식품방사능 | **100.00%** |
+| 재난예경보(21→1,556자) | **100.00%** |
+| 재정동향 | 99.97% |
+| 교육부 | 99.94% |
+| 금융위 | 90.89% (글상자 371자 미처리) |
+
+## 15. P1 / M3 (그리기 개체·글상자) 구현 결과 (2026-06-03)
+
+`HWPMLReader`에 그리기 개체(GSO) 처리 추가:
+- shape 엘리먼트(RECTANGLE/ELLIPSE/ARC/POLYGON/CURVE/LINE/CONTAINER/PICTURE/OLE 등) → `addNewGsoControl` + 확장 컨트롤 문자("gso ").
+- 텍스트 박스(`<DRAWTEXT>`) → shape의 `TextBox` 문단 리스트로 매핑(`createTextBox`/`getTextBox`).
+- 묶음(`<CONTAINER>`) → `ControlContainer`, 자식 shape는 `addNewChildControl`로 재귀(별도 확장 문자 없음 → 불변식 유지).
+
+### 최종 검증 (문자 단위 커버리지, HWP5 추출 대비)
+| 문서 | M3-표 후 | **그리기/글상자 후** |
+|------|:---:|:---:|
+| 중소기업(40,326자) | 100.00% | **100.00%** |
+| 식품방사능 | 100.00% | **100.00%** |
+| 재난예경보 | 100.00% | **100.00%** |
+| 재정동향 | 99.97% | 99.97% |
+| 교육부 | 99.94% | 99.94% |
+| 금융위 | 90.89% | **99.90%** (글상자 복원) |
+
+over-extraction(잉여 추출) 0 — GSO 구조/불변식 정확.
+
+### 잔여 (영향 미미, 내용 손실 아님)
+- 기호 글꼴 문자의 PUA(0xF0000) 오프셋 미적용(교육부 6자): HWP5는 `U+F02Bx`, HWPML은 원본 `U+02Bx`로 표현.
+- 일부 하이픈(페이지번호/구분선 등 자동 컨트롤, 금융위 4·재정동향 1자).
+- 각주/미주/숨은설명 등 일부 컨트롤 텍스트는 추후.
+
+## 16. P2 / C1 구현 결과 (2026-06-03)
+
+레거시 HWP 3.x 리더의 헤더·압축 해제·섹션 구조 파싱:
+- `util/hwp3/Hwp3StreamReader`: 리틀 엔디언 리더(byte/word/dword/…) + `inflateRaw`(raw DEFLATE).
+- `HWP3Reader.fromBytes`: 시그니처 검증 → 문서 정보(128B)에서 압축/암호/sub/정보블록길이 추출 → 압축 영역(오프셋 1166+정보블록) **raw DEFLATE 해제** → 글꼴 이름(7개 언어) + 스타일 섹션 구조 파싱.
+- `object/hwp3/HWP3File`: 헤더 플래그·글꼴/스타일 개수 필드.
+
+### 핵심 확인 사항
+- **압축 방식 = raw DEFLATE**(`Inflater(nowrap=true)`). gzip/zlib 래퍼 아님.
+- 레이아웃: 인식(30)+문서정보(128)+요약(1008)+정보블록(가변, 샘플은 0)+압축영역.
+- 6종 검증: 압축=1·암호=0·sub=1 일치, 글꼴 개수 문서 간 일관(한글~123/영문~196/…), 스타일 2~60 — 해제 스트림 레이아웃 정확.
+
+## 17. P2 / C2 구현 결과 (2026-06-04) — hchar 디코더(핵심 난제 해결)
+
+`util/hwp3/Hwp3CharDecoder`: hchar(2바이트) → 유니코드.
+- 한글 = KS C 5601 **조합형(johab) 5-5-5**(0x8000 비트 + 초성5/중성5/종성5). 비연속 5비트 값을 현대 자모 인덱스로 매핑 후 `0xAC00 + (초*21+중)*28 + 종`.
+- ASCII(0x00~0x7F) 그대로.
+- 한자/기호(0x80~0x7FFF) 변환은 보강 예정.
+
+### 검증 (실제 레거시 파일 코드 디코딩)
+- `B861`→자, `95B7`→동(초ㄷ·중ㅗ·종ㅇ) 등 손 검증 일치.
+- 재난예경보 para#0 → **"자동음성경보장치 (70개소)"**
+- 중소기업 para#0 → **"중소벤처기업부 공고 제2026-287"**
+- 정확한 한국어 복원 확인.
+
+### 잔여 (C3 — 문단/특수문자 순회)
+- 문단 리스트: 문단정보(43/230B)→줄정보(14B×줄수)→글자모양정보→글자들(hchar) 순회.
+- **특수문자(0~31) 인라인 처리**가 관건. 일반형식(표32: code+dwordLen+code+data)과 고정형(탭8/책갈피42/날짜84·96 등)은 명확하나, **표/그림/머리말/각주(코드 10/11/15/16/17)의 중첩 문단 리스트가 글자 스트림 내에서 차지하는 슬롯 수(`글자 수` 산입 방식)가 규격만으로 모호**(실측: 표 문단 nchar=5 = 식별정보 4슬롯+1).
+  → 해당 in-stream 레이아웃은 공개 HWP3 구현(예: `ddoleye/java-hwp`의 `HwpTextExtractorV3`, `pyhwp` hwp3) 교차 참조 또는 코퍼스 기반 추가 리버스 엔지니어링으로 확정 필요.
+- 한자/기호 코드 매핑.
+- **C6**: `Hwp3ToHwpFileConverter`로 `HWPFile` 변환 → 텍스트 추출기 재사용.
+
+## 10. 다음 액션 (착수 전 확인 요청)
+- [ ] §9-1 HWP3 객체 모델 전략 확정
+- [ ] §9-3 검증용 샘플 파일 제공 (3.x 1~2개, HWPML 1~2개)
+- [ ] P0(dispatch 골격) 부터 착수할지 승인
+- [ ] 보조 기능(P4) 포함 여부 — 핵심 우선/보조 보류 권장

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,8 @@
                     <excludes>
                         <exclude>**/sample/**</exclude>
                     </excludes>
-                    <source>7</source>
-                    <target>7</target>
-                    <compilerVersion>1.7</compilerVersion>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <!-- make jar -->

--- a/src/main/java/kr/dogfoot/hwplib/object/hwp3/HWP3File.java
+++ b/src/main/java/kr/dogfoot/hwplib/object/hwp3/HWP3File.java
@@ -1,0 +1,98 @@
+package kr.dogfoot.hwplib.object.hwp3;
+
+/**
+ * 한글 3.x 레거시 바이너리 문서 파일을 나타내는 객체.
+ *
+ * <p>한글 5.0의 {@link kr.dogfoot.hwplib.object.HWPFile}과는 구조가 다르므로 별도의
+ * 전용 객체 모델로 표현한다. 다운스트림 도구(텍스트 추출 등)에서 재사용하려면
+ * {@code kr.dogfoot.hwplib.tool.hwp3conv.Hwp3ToHwpFileConverter}로 변환한다.</p>
+ *
+ * <p>규격: 「한글 문서 파일 형식 3.0 / HWPML」 revision 1.2, Part I (한글 3.x 문서 파일 구조).
+ * 전체 구조(규격 표2)는 다음과 같다.</p>
+ * <pre>
+ *   파일 인식 정보   (30 바이트)
+ *   문서 정보        (128 바이트, 압축/암호 플래그 포함)
+ *   문서 요약        (1008 바이트)
+ *   정보 블록 #0     (가변)
+ *   글꼴 이름        (가변, 압축)
+ *   스타일           (가변, 압축)
+ *   문단 리스트      (가변, 압축)
+ *   추가 정보 블록 #1 (가변, 압축)
+ *   추가 정보 블록 #2 (가변)
+ * </pre>
+ *
+ * <p>현재 구현 단계: C1(헤더 파싱 + 압축 해제 + 글꼴/스타일 섹션 구조 파악)까지.
+ * 문단/글자 파싱(C2/C3)은 이후 단계에서 채운다.</p>
+ */
+public class HWP3File {
+    /** 문서가 압축되어 저장되었는지 여부.(문서 정보 offset 124) */
+    private boolean compressed;
+    /** 암호가 걸린 문서인지 여부.(문서 정보 offset 96) */
+    private boolean hasPassword;
+    /** sub revision.(문서 정보 offset 125) */
+    private int subRevision;
+    /** 정보 블록(#0)의 길이(바이트).(문서 정보 offset 126) */
+    private int infoBlockLength;
+
+    /** 언어별 글꼴 개수.(한글/영문/한자/일어/기타/기호/사용자) */
+    private int[] fontCountPerLanguage = new int[7];
+    /** 스타일 개수. */
+    private int styleCount;
+    /** 파싱된 문단 개수.(본문 최상위 문단 리스트) */
+    private int paragraphCount;
+
+    public HWP3File() {
+    }
+
+    public boolean isCompressed() {
+        return compressed;
+    }
+
+    public void setCompressed(boolean compressed) {
+        this.compressed = compressed;
+    }
+
+    public boolean hasPassword() {
+        return hasPassword;
+    }
+
+    public void setHasPassword(boolean hasPassword) {
+        this.hasPassword = hasPassword;
+    }
+
+    public int getSubRevision() {
+        return subRevision;
+    }
+
+    public void setSubRevision(int subRevision) {
+        this.subRevision = subRevision;
+    }
+
+    public int getInfoBlockLength() {
+        return infoBlockLength;
+    }
+
+    public void setInfoBlockLength(int infoBlockLength) {
+        this.infoBlockLength = infoBlockLength;
+    }
+
+    public int[] getFontCountPerLanguage() {
+        return fontCountPerLanguage;
+    }
+
+    public int getStyleCount() {
+        return styleCount;
+    }
+
+    public void setStyleCount(int styleCount) {
+        this.styleCount = styleCount;
+    }
+
+    public int getParagraphCount() {
+        return paragraphCount;
+    }
+
+    public void setParagraphCount(int paragraphCount) {
+        this.paragraphCount = paragraphCount;
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/reader/FileFormat.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/FileFormat.java
@@ -1,0 +1,18 @@
+package kr.dogfoot.hwplib.reader;
+
+/**
+ * 한글 문서 파일의 종류를 나타내는 열거형.
+ *
+ * <ul>
+ *     <li>{@link #HWP5} : 한글 5.0 형식 (OLE/Compound File 컨테이너)</li>
+ *     <li>{@link #HWP3} : 한글 3.x 레거시 바이너리 형식</li>
+ *     <li>{@link #HWPML} : HWPML(XML) 형식</li>
+ *     <li>{@link #UNKNOWN} : 판별할 수 없는 형식</li>
+ * </ul>
+ */
+public enum FileFormat {
+    HWP5,
+    HWP3,
+    HWPML,
+    UNKNOWN
+}

--- a/src/main/java/kr/dogfoot/hwplib/reader/FormatDetector.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/FormatDetector.java
@@ -1,0 +1,109 @@
+package kr.dogfoot.hwplib.reader;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 파일의 앞부분 바이트를 보고 한글 문서 파일의 종류({@link FileFormat})를 판별하는 객체.
+ *
+ * <ul>
+ *     <li>HWP5 : OLE2/Compound File 시그니처(D0 CF 11 E0 A1 B1 1A E1)로 시작</li>
+ *     <li>HWP3 : 텍스트 "HWP Document File V3.00"로 시작</li>
+ *     <li>HWPML : (BOM 이후) "&lt;?xml" 또는 "&lt;HWPML"로 시작하는 XML</li>
+ * </ul>
+ */
+public class FormatDetector {
+    /**
+     * OLE2/Compound File Binary 시그니처. 한글 5.0 파일의 컨테이너 형식.
+     */
+    private static final byte[] OLE_SIGNATURE = {
+            (byte) 0xD0, (byte) 0xCF, (byte) 0x11, (byte) 0xE0,
+            (byte) 0xA1, (byte) 0xB1, (byte) 0x1A, (byte) 0xE1
+    };
+
+    /**
+     * 한글 3.x 파일 인식 정보의 텍스트 시그니처.
+     * 전체 인식 정보는 "HWP Document File V3.00 \x1a\1\2\3\4\5" (30바이트)이다.
+     */
+    public static final String HWP3_SIGNATURE_TEXT = "HWP Document File V3.00";
+
+    private static final byte[] HWP3_SIGNATURE =
+            HWP3_SIGNATURE_TEXT.getBytes(StandardCharsets.US_ASCII);
+
+    /**
+     * 판별을 위해 읽어야 하는 최소 바이트 수 권장값.
+     */
+    public static final int RECOMMENDED_HEAD_SIZE = 1024;
+
+    /**
+     * 파일 앞부분 바이트로 파일 형식을 판별한다.
+     *
+     * @param head 파일의 앞부분 바이트 (최소 {@link #RECOMMENDED_HEAD_SIZE}바이트 권장)
+     * @return 판별된 파일 형식. 알 수 없으면 {@link FileFormat#UNKNOWN}
+     */
+    public static FileFormat detect(byte[] head) {
+        if (head == null || head.length == 0) {
+            return FileFormat.UNKNOWN;
+        }
+        if (startsWith(head, 0, OLE_SIGNATURE)) {
+            return FileFormat.HWP5;
+        }
+        if (startsWith(head, 0, HWP3_SIGNATURE)) {
+            return FileFormat.HWP3;
+        }
+        if (looksLikeHWPML(head)) {
+            return FileFormat.HWPML;
+        }
+        return FileFormat.UNKNOWN;
+    }
+
+    private static boolean startsWith(byte[] data, int offset, byte[] prefix) {
+        if (data.length - offset < prefix.length) {
+            return false;
+        }
+        for (int i = 0; i < prefix.length; i++) {
+            if (data[offset + i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * BOM과 인코딩(UTF-8 / UTF-16)을 고려하여 XML(HWPML)인지 느슨하게 판별한다.
+     */
+    private static boolean looksLikeHWPML(byte[] head) {
+        int offset = skipBom(head);
+        // UTF-16 형식은 ASCII 문자 사이에 0x00이 끼어 있으므로 0x00을 제거하고 검사한다.
+        StringBuilder sb = new StringBuilder();
+        for (int i = offset; i < head.length && sb.length() < 256; i++) {
+            byte b = head[i];
+            if (b == 0x00) {
+                continue;
+            }
+            sb.append((char) (b & 0xFF));
+        }
+        String text = sb.toString().trim();
+        String lower = text.toLowerCase();
+        if (lower.startsWith("<?xml")) {
+            // XML 선언 이후 어딘가에 <HWPML 루트가 있는지 확인한다.
+            return lower.contains("<hwpml");
+        }
+        return lower.startsWith("<hwpml");
+    }
+
+    /**
+     * UTF-8 / UTF-16 BOM 길이만큼 건너뛴 오프셋을 반환한다.
+     */
+    private static int skipBom(byte[] head) {
+        if (head.length >= 3
+                && (head[0] & 0xFF) == 0xEF && (head[1] & 0xFF) == 0xBB && (head[2] & 0xFF) == 0xBF) {
+            return 3; // UTF-8 BOM
+        }
+        if (head.length >= 2
+                && ((head[0] & 0xFF) == 0xFF && (head[1] & 0xFF) == 0xFE
+                || (head[0] & 0xFF) == 0xFE && (head[1] & 0xFF) == 0xFF)) {
+            return 2; // UTF-16 LE/BE BOM
+        }
+        return 0;
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/reader/HWPLibReader.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/HWPLibReader.java
@@ -1,0 +1,103 @@
+package kr.dogfoot.hwplib.reader;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.hwp3.HWP3File;
+import kr.dogfoot.hwplib.reader.hwp3.HWP3Reader;
+import kr.dogfoot.hwplib.reader.hwpml.HWPMLReader;
+import kr.dogfoot.hwplib.tool.hwp3conv.Hwp3ToHwpFileConverter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+/**
+ * 파일 형식(한글 5.0 / 한글 3.x / HWPML)을 자동으로 판별하여 알맞은 리더로 위임하는
+ * 통합 진입점.
+ *
+ * <p>모든 형식을 공통 객체 모델인 {@link HWPFile}로 반환한다. 한글 3.x의 경우
+ * {@link HWP3Reader}로 전용 모델을 읽은 뒤 {@link Hwp3ToHwpFileConverter}로 변환한다.
+ * 한글 3.x의 충실한 전용 모델({@link HWP3File})이 필요하면 {@link HWP3Reader}를 직접
+ * 사용한다.</p>
+ */
+public class HWPLibReader {
+    /**
+     * 파일을 읽어 형식에 맞게 파싱한다.
+     *
+     * @param filepath 파일 경로
+     * @return 공통 객체 모델 {@link HWPFile}
+     * @throws Exception 형식을 판별할 수 없거나 읽기 오류가 발생한 경우
+     */
+    public static HWPFile fromFile(String filepath) throws Exception {
+        return fromInputStream(new FileInputStream(filepath));
+    }
+
+    /**
+     * 파일을 읽어 형식에 맞게 파싱한다.
+     *
+     * @param file 파일
+     * @return 공통 객체 모델 {@link HWPFile}
+     * @throws Exception 형식을 판별할 수 없거나 읽기 오류가 발생한 경우
+     */
+    public static HWPFile fromFile(File file) throws Exception {
+        return fromInputStream(new FileInputStream(file));
+    }
+
+    /**
+     * 입력 스트림을 읽어 형식에 맞게 파싱한다.
+     *
+     * @param is 입력 스트림
+     * @return 공통 객체 모델 {@link HWPFile}
+     * @throws Exception 형식을 판별할 수 없거나 읽기 오류가 발생한 경우
+     */
+    public static HWPFile fromInputStream(InputStream is) throws Exception {
+        return fromBytes(readAll(is));
+    }
+
+    /**
+     * 파일 전체 바이트를 읽어 형식에 맞게 파싱한다.
+     *
+     * @param data 파일 전체 바이트
+     * @return 공통 객체 모델 {@link HWPFile}
+     * @throws Exception 형식을 판별할 수 없거나 읽기 오류가 발생한 경우
+     */
+    public static HWPFile fromBytes(byte[] data) throws Exception {
+        FileFormat format = detectFormat(data);
+        switch (format) {
+            case HWP5:
+                return HWPReader.fromInputStream(new ByteArrayInputStream(data));
+            case HWPML:
+                return HWPMLReader.fromBytes(data);
+            case HWP3:
+                HWP3File hwp3 = HWP3Reader.fromBytes(data);
+                return Hwp3ToHwpFileConverter.convert(hwp3);
+            default:
+                throw new Exception("Unknown or unsupported file format.");
+        }
+    }
+
+    /**
+     * 파일 전체 바이트로 형식을 판별한다.
+     *
+     * @param data 파일 바이트
+     * @return 판별된 {@link FileFormat}
+     */
+    public static FileFormat detectFormat(byte[] data) {
+        return FormatDetector.detect(data);
+    }
+
+    private static byte[] readAll(InputStream is) throws Exception {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                bos.write(buffer, 0, read);
+            }
+            return bos.toByteArray();
+        } finally {
+            is.close();
+        }
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/reader/HWPReader.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/HWPReader.java
@@ -17,7 +17,7 @@ import kr.dogfoot.hwplib.tool.textextractor.TextExtractorListener;
 import kr.dogfoot.hwplib.util.compoundFile.reader.CompoundFileReader;
 import kr.dogfoot.hwplib.util.compoundFile.reader.StreamReader;
 
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 import java.io.*;
 import java.net.URL;
 import java.util.Iterator;
@@ -106,7 +106,7 @@ public class HWPReader {
     }
 
     public static HWPFile fromBase64String(String base64) throws Exception {
-        byte[] binary = DatatypeConverter.parseBase64Binary(base64);
+        byte[] binary = Base64.getMimeDecoder().decode(base64);
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(binary);
         return HWPReader.fromInputStream(byteArrayInputStream);
     }

--- a/src/main/java/kr/dogfoot/hwplib/reader/hwp3/HWP3Reader.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/hwp3/HWP3Reader.java
@@ -1,0 +1,157 @@
+package kr.dogfoot.hwplib.reader.hwp3;
+
+import kr.dogfoot.hwplib.object.hwp3.HWP3File;
+import kr.dogfoot.hwplib.reader.FileFormat;
+import kr.dogfoot.hwplib.reader.FormatDetector;
+import kr.dogfoot.hwplib.util.hwp3.Hwp3StreamReader;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * 한글 3.x 레거시 바이너리 파일을 읽기 위한 객체.
+ *
+ * <p>규격: 「한글 문서 파일 형식 3.0 / HWPML」 revision 1.2, Part I.</p>
+ *
+ * <p>현재 P0 단계의 골격이다. 시그니처 검증까지만 구현되어 있고, 본문 파싱은
+ * 이후 단계(P2: 헤더/gzip 해제/문단 텍스트)에서 구현한다.</p>
+ */
+public class HWP3Reader {
+    /**
+     * 파일 인식 정보의 길이(바이트).
+     */
+    public static final int FILE_RECOGNITION_SIZE = 30;
+    /** 문서 정보의 길이(바이트). */
+    public static final int DOC_INFO_SIZE = 128;
+    /** 문서 요약의 길이(바이트). */
+    public static final int DOC_SUMMARY_SIZE = 1008;
+    /** 글꼴 이름 하나의 길이(kchar array[40]). */
+    public static final int FONT_NAME_LENGTH = 40;
+    /** 스타일 정보 하나의 길이(바이트). */
+    public static final int STYLE_INFO_SIZE = 238;
+
+    /**
+     * hwp 3.x 파일을 읽는다.
+     *
+     * @param filepath 파일 경로
+     * @return HWP3File 객체
+     * @throws Exception 파일을 읽는 도중 오류가 발생한 경우
+     */
+    public static HWP3File fromFile(String filepath) throws Exception {
+        return fromInputStream(new FileInputStream(filepath));
+    }
+
+    /**
+     * hwp 3.x 파일을 읽는다.
+     *
+     * @param file 파일
+     * @return HWP3File 객체
+     * @throws Exception 파일을 읽는 도중 오류가 발생한 경우
+     */
+    public static HWP3File fromFile(File file) throws Exception {
+        return fromInputStream(new FileInputStream(file));
+    }
+
+    /**
+     * hwp 3.x 파일을 읽는다.
+     *
+     * @param is 입력 스트림
+     * @return HWP3File 객체
+     * @throws Exception 파일을 읽는 도중 오류가 발생한 경우
+     */
+    public static HWP3File fromInputStream(InputStream is) throws Exception {
+        byte[] data = readAll(is);
+        return fromBytes(data);
+    }
+
+    /**
+     * hwp 3.x 파일의 전체 바이트를 읽는다.
+     *
+     * @param data 파일 전체 바이트
+     * @return HWP3File 객체
+     * @throws Exception 시그니처가 올바르지 않거나 아직 미구현인 경우
+     */
+    public static HWP3File fromBytes(byte[] data) throws Exception {
+        if (!isHWP3(data)) {
+            throw new Exception("Not a HWP 3.x file. (signature mismatch)");
+        }
+
+        HWP3File file = new HWP3File();
+
+        // 문서 정보(128바이트, 파일 오프셋 30~157)에서 필요한 플래그를 읽는다.(규격 표3)
+        final int docInfoOffset = FILE_RECOGNITION_SIZE; // 30
+        int password = uint16(data, docInfoOffset + 96);
+        boolean compressed = uint8(data, docInfoOffset + 124) != 0;
+        int subRevision = uint8(data, docInfoOffset + 125);
+        int infoBlockLength = uint16(data, docInfoOffset + 126);
+
+        file.setHasPassword(password != 0);
+        file.setCompressed(compressed);
+        file.setSubRevision(subRevision);
+        file.setInfoBlockLength(infoBlockLength);
+
+        if (password != 0) {
+            throw new Exception("Password-protected HWP 3.x files are not supported.");
+        }
+
+        // 압축 영역 시작: 인식(30) + 문서정보(128) + 문서요약(1008) + 정보블록(infoBlockLength)
+        int bodyOffset = FILE_RECOGNITION_SIZE + DOC_INFO_SIZE + DOC_SUMMARY_SIZE + infoBlockLength;
+
+        // 글꼴 이름 ~ 추가 정보 블록 #1은 raw DEFLATE로 압축되어 있다.
+        byte[] body = compressed
+                ? Hwp3StreamReader.inflateRaw(data, bodyOffset)
+                : Arrays.copyOfRange(data, bodyOffset, data.length);
+
+        Hwp3StreamReader sr = new Hwp3StreamReader(body);
+
+        // 글꼴 이름: 7개 언어별로 (word nfonts, kchar fontnames[nfonts][40])
+        for (int lang = 0; lang < 7; lang++) {
+            int nfonts = sr.readUInt16();
+            file.getFontCountPerLanguage()[lang] = nfonts;
+            sr.skip(nfonts * FONT_NAME_LENGTH);
+        }
+
+        // 스타일: word nstyles, { 스타일 정보(238바이트) } x nstyles
+        int nstyles = sr.readUInt16();
+        file.setStyleCount(nstyles);
+        sr.skip(nstyles * STYLE_INFO_SIZE);
+
+        // TODO(C3): 문단 리스트 파싱(문단 정보/줄 정보/글자 모양/글자들) + hchar 디코딩
+        return file;
+    }
+
+    /**
+     * 주어진 바이트가 한글 3.x 파일 인식 정보 시그니처로 시작하는지 확인한다.
+     *
+     * @param data 파일 앞부분 바이트
+     * @return 한글 3.x 시그니처이면 true
+     */
+    public static boolean isHWP3(byte[] data) {
+        return FormatDetector.detect(data) == FileFormat.HWP3;
+    }
+
+    private static int uint8(byte[] b, int offset) {
+        return b[offset] & 0xFF;
+    }
+
+    private static int uint16(byte[] b, int offset) {
+        return (b[offset] & 0xFF) | ((b[offset + 1] & 0xFF) << 8);
+    }
+
+    private static byte[] readAll(InputStream is) throws Exception {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                bos.write(buffer, 0, read);
+            }
+            return bos.toByteArray();
+        } finally {
+            is.close();
+        }
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/reader/hwpml/ForHead.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/hwpml/ForHead.java
@@ -1,0 +1,318 @@
+package kr.dogfoot.hwplib.reader.hwpml;
+
+import kr.dogfoot.hwplib.object.docinfo.CharShape;
+import kr.dogfoot.hwplib.object.docinfo.DocInfo;
+import kr.dogfoot.hwplib.object.docinfo.FaceName;
+import kr.dogfoot.hwplib.object.docinfo.IDMappings;
+import kr.dogfoot.hwplib.object.docinfo.Numbering;
+import kr.dogfoot.hwplib.object.docinfo.ParaShape;
+import kr.dogfoot.hwplib.object.docinfo.Style;
+import kr.dogfoot.hwplib.object.docinfo.numbering.LevelNumbering;
+import kr.dogfoot.hwplib.object.docinfo.numbering.ParagraphNumberFormat;
+import kr.dogfoot.hwplib.object.docinfo.parashape.Alignment;
+import kr.dogfoot.hwplib.object.docinfo.parashape.ParaHeadShape;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+
+/**
+ * HWPML의 {@code <HEAD>} 영역(MAPPINGTABLE 등)을 {@link DocInfo}로 매핑하는 객체.
+ *
+ * <p>규격: 「한글 문서 파일 형식 3.0 / HWPML」 revision 1.2, Part II §4.</p>
+ *
+ * <p>현재 단계(M2)에서 매핑하는 항목: 글꼴(FONTFACE/FONT), 테두리/채우기(BORDERFILL,
+ * 개수만), 글자 모양(CHARSHAPE), 탭(TABDEF, 개수만), 번호 정의(NUMBERING), 글머리표
+ * (BULLET, 개수만), 문단 모양(PARASHAPE), 스타일(STYLE). 텍스트 추출에 필요한
+ * 핵심 필드를 우선 채우고, 세부 속성은 이후 보강한다.</p>
+ */
+public class ForHead {
+    /**
+     * {@code <HEAD>} 시작 엘리먼트에 위치한 상태에서 호출한다. {@code </HEAD>}까지 읽어
+     * {@link DocInfo}를 채운다.
+     */
+    public static void read(XMLStreamReader xr, DocInfo docInfo) throws Exception {
+        CharShape curCharShape = null;
+        ParaShape curParaShape = null;
+        Numbering curNumbering = null;
+        String curFaceLang = null;
+
+        boolean capturingParaHead = false;
+        int paraHeadLevel = 0;
+        StringBuilder paraHeadText = new StringBuilder();
+
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String name = xr.getLocalName();
+                if ("FONTFACE".equals(name)) {
+                    curFaceLang = attr(xr, "Lang");
+                } else if ("FONT".equals(name)) {
+                    FaceName fn = addFaceName(docInfo, curFaceLang);
+                    if (fn != null) {
+                        fn.setName(attr(xr, "Name"));
+                    }
+                } else if ("BORDERFILL".equals(name)) {
+                    docInfo.addNewBorderFill();
+                } else if ("CHARSHAPE".equals(name)) {
+                    curCharShape = docInfo.addNewCharShape();
+                    curCharShape.setBaseSize(intAttr(xr, "Height", 1000));
+                    curCharShape.getCharColor().setValue(longAttr(xr, "TextColor", 0));
+                    curCharShape.setBorderFillId(intAttr(xr, "BorderFillId", 0));
+                } else if ("FONTID".equals(name) && curCharShape != null) {
+                    curCharShape.getFaceNameIds().setHangul(intAttr(xr, "Hangul", 0));
+                    curCharShape.getFaceNameIds().setLatin(intAttr(xr, "Latin", 0));
+                    curCharShape.getFaceNameIds().setHanja(intAttr(xr, "Hanja", 0));
+                    curCharShape.getFaceNameIds().setJapanese(intAttr(xr, "Japanese", 0));
+                    curCharShape.getFaceNameIds().setOther(intAttr(xr, "Other", 0));
+                    curCharShape.getFaceNameIds().setSymbol(intAttr(xr, "Symbol", 0));
+                    curCharShape.getFaceNameIds().setUser(intAttr(xr, "User", 0));
+                } else if ("RATIO".equals(name) && curCharShape != null) {
+                    curCharShape.getRatios().setHangul((short) intAttr(xr, "Hangul", 100));
+                    curCharShape.getRatios().setLatin((short) intAttr(xr, "Latin", 100));
+                    curCharShape.getRatios().setHanja((short) intAttr(xr, "Hanja", 100));
+                    curCharShape.getRatios().setJapanese((short) intAttr(xr, "Japanese", 100));
+                    curCharShape.getRatios().setOther((short) intAttr(xr, "Other", 100));
+                    curCharShape.getRatios().setSymbol((short) intAttr(xr, "Symbol", 100));
+                    curCharShape.getRatios().setUser((short) intAttr(xr, "User", 100));
+                } else if ("CHARSPACING".equals(name) && curCharShape != null) {
+                    curCharShape.getCharSpaces().setHangul((byte) intAttr(xr, "Hangul", 0));
+                    curCharShape.getCharSpaces().setLatin((byte) intAttr(xr, "Latin", 0));
+                    curCharShape.getCharSpaces().setHanja((byte) intAttr(xr, "Hanja", 0));
+                    curCharShape.getCharSpaces().setJapanese((byte) intAttr(xr, "Japanese", 0));
+                    curCharShape.getCharSpaces().setOther((byte) intAttr(xr, "Other", 0));
+                    curCharShape.getCharSpaces().setSymbol((byte) intAttr(xr, "Symbol", 0));
+                    curCharShape.getCharSpaces().setUser((byte) intAttr(xr, "User", 0));
+                } else if ("RELSIZE".equals(name) && curCharShape != null) {
+                    curCharShape.getRelativeSizes().setHangul((short) intAttr(xr, "Hangul", 100));
+                    curCharShape.getRelativeSizes().setLatin((short) intAttr(xr, "Latin", 100));
+                    curCharShape.getRelativeSizes().setHanja((short) intAttr(xr, "Hanja", 100));
+                    curCharShape.getRelativeSizes().setJapanese((short) intAttr(xr, "Japanese", 100));
+                    curCharShape.getRelativeSizes().setOther((short) intAttr(xr, "Other", 100));
+                    curCharShape.getRelativeSizes().setSymbol((short) intAttr(xr, "Symbol", 100));
+                    curCharShape.getRelativeSizes().setUser((short) intAttr(xr, "User", 100));
+                } else if ("CHAROFFSET".equals(name) && curCharShape != null) {
+                    curCharShape.getCharOffsets().setHangul((byte) intAttr(xr, "Hangul", 0));
+                    curCharShape.getCharOffsets().setLatin((byte) intAttr(xr, "Latin", 0));
+                    curCharShape.getCharOffsets().setHanja((byte) intAttr(xr, "Hanja", 0));
+                    curCharShape.getCharOffsets().setJapanese((byte) intAttr(xr, "Japanese", 0));
+                    curCharShape.getCharOffsets().setOther((byte) intAttr(xr, "Other", 0));
+                    curCharShape.getCharOffsets().setSymbol((byte) intAttr(xr, "Symbol", 0));
+                    curCharShape.getCharOffsets().setUser((byte) intAttr(xr, "User", 0));
+                } else if ("BOLD".equals(name) && curCharShape != null) {
+                    curCharShape.getProperty().setBold(true);
+                } else if ("ITALIC".equals(name) && curCharShape != null) {
+                    curCharShape.getProperty().setItalic(true);
+                } else if ("TABDEF".equals(name)) {
+                    docInfo.addNewTabDef();
+                } else if ("NUMBERING".equals(name)) {
+                    curNumbering = docInfo.addNewNumbering();
+                    curNumbering.setStartNumber(intAttr(xr, "Start", 0));
+                } else if ("PARAHEAD".equals(name) && curNumbering != null) {
+                    paraHeadLevel = intAttr(xr, "Level", 1);
+                    LevelNumbering lv = levelNumbering(curNumbering, paraHeadLevel);
+                    if (lv != null) {
+                        lv.setStartNumber(intAttr(xr, "Start", 1));
+                        lv.getParagraphHeadInfo().getProperty()
+                                .setParagraphNumberFormat(numberFormat(attr(xr, "NumFormat")));
+                    }
+                    capturingParaHead = true;
+                    paraHeadText.setLength(0);
+                } else if ("BULLET".equals(name)) {
+                    docInfo.addNewBullet();
+                } else if ("PARASHAPE".equals(name)) {
+                    curParaShape = docInfo.addNewParaShape();
+                    curParaShape.getProperty1().setAlignment(alignment(attr(xr, "Align")));
+                    curParaShape.getProperty1().setParaHeadShape(paraHeadShape(attr(xr, "HeadingType")));
+                    curParaShape.setParaHeadId(intAttr(xr, "Heading", 0));
+                    curParaShape.setTabDefId(intAttr(xr, "TabDef", 0));
+                    curParaShape.getProperty1().setParaLevel((byte) intAttr(xr, "Level", 0));
+                } else if ("PARAMARGIN".equals(name) && curParaShape != null) {
+                    curParaShape.setIndent(intAttr(xr, "Indent", 0));
+                    curParaShape.setLeftMargin(intAttr(xr, "Left", 0));
+                    curParaShape.setRightMargin(intAttr(xr, "Right", 0));
+                    curParaShape.setTopParaSpace(intAttr(xr, "Prev", 0));
+                    curParaShape.setBottomParaSpace(intAttr(xr, "Next", 0));
+                    curParaShape.setLineSpace2(longAttr(xr, "LineSpacing", 0));
+                } else if ("STYLE".equals(name)) {
+                    Style st = docInfo.addNewStyle();
+                    st.setHangulName(attr(xr, "Name"));
+                    st.setEnglishName(attr(xr, "EngName"));
+                    st.setParaShapeId(intAttr(xr, "ParaShape", 0));
+                    st.setCharShapeId(intAttr(xr, "CharShape", 0));
+                    st.setNextStyleId((short) intAttr(xr, "NextStyle", 0));
+                    st.setLanguageId((short) intAttr(xr, "LangId", 0));
+                }
+            } else if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA) {
+                if (capturingParaHead) {
+                    paraHeadText.append(xr.getText());
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                String name = xr.getLocalName();
+                if ("PARAHEAD".equals(name) && curNumbering != null) {
+                    LevelNumbering lv = levelNumbering(curNumbering, paraHeadLevel);
+                    if (lv != null) {
+                        lv.getNumberFormat().fromUTF16LEString(stripTrailingLineTerminator(paraHeadText.toString()));
+                    }
+                    capturingParaHead = false;
+                } else if ("HEAD".equals(name)) {
+                    break;
+                }
+            }
+        }
+
+        setCounts(docInfo);
+    }
+
+    private static FaceName addFaceName(DocInfo docInfo, String lang) {
+        if (lang == null) {
+            return docInfo.addNewHangulFaceName();
+        }
+        switch (lang) {
+            case "Hangul":
+                return docInfo.addNewHangulFaceName();
+            case "Latin":
+                return docInfo.addNewEnglishFaceName();
+            case "Hanja":
+                return docInfo.addNewHanjaFaceName();
+            case "Japanese":
+                return docInfo.addNewJapaneseFaceName();
+            case "Other":
+                return docInfo.addNewEtcFaceName();
+            case "Symbol":
+                return docInfo.addNewSymbolFaceName();
+            case "User":
+                return docInfo.addNewUserFaceName();
+            default:
+                return docInfo.addNewHangulFaceName();
+        }
+    }
+
+    private static LevelNumbering levelNumbering(Numbering numbering, int level) throws Exception {
+        if (level < 1 || level > 10) {
+            return null;
+        }
+        return numbering.getLevelNumbering(level);
+    }
+
+    private static ParaHeadShape paraHeadShape(String headingType) {
+        if (headingType == null) {
+            return ParaHeadShape.None;
+        }
+        switch (headingType) {
+            case "Outline":
+                return ParaHeadShape.Outline;
+            case "Number":
+            case "Numbering":
+                return ParaHeadShape.Numbering;
+            case "Bullet":
+                return ParaHeadShape.Bullet;
+            default:
+                return ParaHeadShape.None;
+        }
+    }
+
+    private static Alignment alignment(String align) {
+        if (align == null) {
+            return Alignment.Justify;
+        }
+        switch (align) {
+            case "Left":
+                return Alignment.Left;
+            case "Right":
+                return Alignment.Right;
+            case "Center":
+                return Alignment.Center;
+            case "Distribute":
+                return Alignment.Distribute;
+            case "Divide":
+                return Alignment.Divide;
+            case "Justify":
+            default:
+                return Alignment.Justify;
+        }
+    }
+
+    private static ParagraphNumberFormat numberFormat(String numFormat) {
+        if (numFormat == null) {
+            return ParagraphNumberFormat.Number;
+        }
+        switch (numFormat) {
+            case "Digit":
+                return ParagraphNumberFormat.Number;
+            case "CircledDigit":
+                return ParagraphNumberFormat.CircledNumber;
+            case "RomanCapital":
+                return ParagraphNumberFormat.UppercaseRomanNumber;
+            case "RomanSmall":
+                return ParagraphNumberFormat.LowercaseRomanNumber;
+            case "LatinCapital":
+                return ParagraphNumberFormat.UppercaseAlphabet;
+            case "LatinSmall":
+                return ParagraphNumberFormat.LowercaseAlphabet;
+            case "HangulSyllable":
+                return ParagraphNumberFormat.Hangul;
+            case "HangulJamo":
+                return ParagraphNumberFormat.HangulJamo;
+            case "Ideograph":
+                return ParagraphNumberFormat.HanjaNumber;
+            default:
+                return ParagraphNumberFormat.Number;
+        }
+    }
+
+    private static void setCounts(DocInfo docInfo) {
+        IDMappings idm = docInfo.getIDMappings();
+        idm.setHangulFaceNameCount(docInfo.getHangulFaceNameList().size());
+        idm.setEnglishFaceNameCount(docInfo.getEnglishFaceNameList().size());
+        idm.setHanjaFaceNameCount(docInfo.getHanjaFaceNameList().size());
+        idm.setJapaneseFaceNameCount(docInfo.getJapaneseFaceNameList().size());
+        idm.setEtcFaceNameCount(docInfo.getEtcFaceNameList().size());
+        idm.setSymbolFaceNameCount(docInfo.getSymbolFaceNameList().size());
+        idm.setUserFaceNameCount(docInfo.getUserFaceNameList().size());
+        idm.setBorderFillCount(docInfo.getBorderFillList().size());
+        idm.setCharShapeCount(docInfo.getCharShapeList().size());
+        idm.setTabDefCount(docInfo.getTabDefList().size());
+        idm.setNumberingCount(docInfo.getNumberingList().size());
+        idm.setBulletCount(docInfo.getBulletList().size());
+        idm.setParaShapeCount(docInfo.getParaShapeList().size());
+        idm.setStyleCount(docInfo.getStyleList().size());
+    }
+
+    private static String stripTrailingLineTerminator(String s) {
+        if (s.endsWith("\r\n")) {
+            return s.substring(0, s.length() - 2);
+        }
+        if (s.endsWith("\n") || s.endsWith("\r")) {
+            return s.substring(0, s.length() - 1);
+        }
+        return s;
+    }
+
+    private static String attr(XMLStreamReader xr, String name) {
+        return xr.getAttributeValue(null, name);
+    }
+
+    private static int intAttr(XMLStreamReader xr, String name, int defaultValue) {
+        String v = xr.getAttributeValue(null, name);
+        if (v == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(v.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private static long longAttr(XMLStreamReader xr, String name, long defaultValue) {
+        String v = xr.getAttributeValue(null, name);
+        if (v == null) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(v.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/reader/hwpml/HWPMLReader.java
+++ b/src/main/java/kr/dogfoot/hwplib/reader/hwpml/HWPMLReader.java
@@ -1,0 +1,530 @@
+package kr.dogfoot.hwplib.reader.hwpml;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.bodytext.BodyText;
+import kr.dogfoot.hwplib.object.bodytext.ParagraphListInterface;
+import kr.dogfoot.hwplib.object.bodytext.Section;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.ControlArc;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.ControlContainer;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.ControlCurve;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.ControlEllipse;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.ControlPolygon;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.ControlRectangle;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.GsoControl;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.GsoControlType;
+import kr.dogfoot.hwplib.object.bodytext.control.gso.textbox.TextBox;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Cell;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Row;
+import kr.dogfoot.hwplib.object.bodytext.control.table.ListHeaderForCell;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.charshape.ParaCharShape;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.header.ParaHeader;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.text.HWPCharControlExtend;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.text.ParaText;
+import kr.dogfoot.hwplib.reader.FileFormat;
+import kr.dogfoot.hwplib.reader.FormatDetector;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * HWPML(XML) 파일을 읽기 위한 객체.
+ *
+ * <p>규격: 「한글 문서 파일 형식 3.0 / HWPML」 revision 1.2, Part II.</p>
+ *
+ * <p>HWPML은 한글 5.0과 의미상 동형이므로 기존 {@link HWPFile} 객체 모델에 직접
+ * 매핑한다. 재귀 하강 방식으로 파싱하여 표 셀 안의 중첩 문단(및 중첩 표)을 자연스럽게
+ * 처리한다.</p>
+ *
+ * <p>구현 범위:
+ * <ul>
+ *     <li>HEAD → DocInfo (글꼴/글자모양/문단모양/스타일/번호 등, {@link ForHead})</li>
+ *     <li>BODY → Section/Paragraph/글자(TEXT/CHAR)</li>
+ *     <li>표(TABLE) → {@link ControlTable} (행/열/셀/셀 문단)</li>
+ * </ul>
+ * 그림·그리기 개체·글상자·각주 등 그 외 컨트롤은 아직 본문에서 건너뛴다.(이후 단계)</p>
+ */
+public class HWPMLReader {
+    /**
+     * HWPML 그리기 개체 엘리먼트 이름 → GSO 컨트롤 종류 매핑.
+     */
+    private static final Map<String, GsoControlType> SHAPE_TYPE = new HashMap<String, GsoControlType>();
+
+    static {
+        SHAPE_TYPE.put("LINE", GsoControlType.Line);
+        SHAPE_TYPE.put("RECTANGLE", GsoControlType.Rectangle);
+        SHAPE_TYPE.put("ELLIPSE", GsoControlType.Ellipse);
+        SHAPE_TYPE.put("ARC", GsoControlType.Arc);
+        SHAPE_TYPE.put("POLYGON", GsoControlType.Polygon);
+        SHAPE_TYPE.put("CURVE", GsoControlType.Curve);
+        SHAPE_TYPE.put("CONNECTLINE", GsoControlType.ObjectLinkLine);
+        SHAPE_TYPE.put("CONTAINER", GsoControlType.Container);
+        SHAPE_TYPE.put("PICTURE", GsoControlType.Picture);
+        SHAPE_TYPE.put("OLE", GsoControlType.OLE);
+        SHAPE_TYPE.put("TEXTART", GsoControlType.TextArt);
+    }
+
+    /**
+     * HWPML 파일을 읽는다.
+     *
+     * @param filepath 파일 경로
+     * @return HWPFile 객체
+     * @throws Exception 파일을 읽는 도중 오류가 발생한 경우
+     */
+    public static HWPFile fromFile(String filepath) throws Exception {
+        return fromInputStream(new FileInputStream(filepath));
+    }
+
+    /**
+     * HWPML 파일을 읽는다.
+     *
+     * @param file 파일
+     * @return HWPFile 객체
+     * @throws Exception 파일을 읽는 도중 오류가 발생한 경우
+     */
+    public static HWPFile fromFile(File file) throws Exception {
+        return fromInputStream(new FileInputStream(file));
+    }
+
+    /**
+     * HWPML 파일을 읽는다.
+     *
+     * @param is 입력 스트림
+     * @return HWPFile 객체
+     * @throws Exception 파일을 읽는 도중 오류가 발생한 경우
+     */
+    public static HWPFile fromInputStream(InputStream is) throws Exception {
+        byte[] data = readAll(is);
+        return fromBytes(data);
+    }
+
+    /**
+     * HWPML 파일의 전체 바이트를 읽는다.
+     *
+     * @param data 파일 전체 바이트
+     * @return HWPFile 객체
+     * @throws Exception XML이 아니거나 파싱 오류가 발생한 경우
+     */
+    public static HWPFile fromBytes(byte[] data) throws Exception {
+        if (!isHWPML(data)) {
+            throw new Exception("Not a HWPML file. (root element mismatch)");
+        }
+        HWPFile hwpFile = new HWPFile();
+        XMLStreamReader xr = createStreamReader(new ByteArrayInputStream(data));
+        try {
+            new HWPMLReader().parse(xr, hwpFile);
+        } finally {
+            xr.close();
+        }
+        return hwpFile;
+    }
+
+    /**
+     * 주어진 바이트가 HWPML 형식인지 확인한다.
+     *
+     * @param data 파일 앞부분 바이트
+     * @return HWPML이면 true
+     */
+    public static boolean isHWPML(byte[] data) {
+        return FormatDetector.detect(data) == FileFormat.HWPML;
+    }
+
+    /**
+     * 문서 루트를 순회하며 HEAD/BODY를 처리한다.
+     */
+    private void parse(XMLStreamReader xr, HWPFile hwpFile) throws Exception {
+        BodyText bodyText = hwpFile.getBodyText();
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String name = xr.getLocalName();
+                if ("HEAD".equals(name)) {
+                    ForHead.read(xr, hwpFile.getDocInfo());
+                } else if ("SECTION".equals(name)) {
+                    readSection(bodyText.addNewSection(), xr);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@code <SECTION>} 시작에 위치한 상태에서 호출. {@code </SECTION>}까지 문단을 읽는다.
+     */
+    private void readSection(Section section, XMLStreamReader xr) throws Exception {
+        boolean first = true;
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                if ("P".equals(xr.getLocalName())) {
+                    Paragraph p = readParagraph(section, xr);
+                    if (first) {
+                        // TextExtractor가 구역 첫 문단의 컨트롤 리스트(구역 정의)를 참조하므로 비어 있어도 만들어 둔다.
+                        if (p.getControlList() == null) {
+                            p.createControlList();
+                        }
+                        first = false;
+                    }
+                } else {
+                    skipSubtree(xr);
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "SECTION".equals(xr.getLocalName())) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * {@code <P>} 시작에 위치한 상태에서 호출. {@code </P>}까지 글자/표를 읽어 문단을 만든다.
+     *
+     * @return 생성된 문단
+     */
+    private Paragraph readParagraph(ParagraphListInterface container, XMLStreamReader xr) throws Exception {
+        Paragraph para = container.addNewParagraph();
+        para.createText();
+        para.createCharShape();
+        ParaText text = para.getText();
+        ParaCharShape charShape = para.getCharShape();
+
+        ParaHeader header = para.getHeader();
+        header.setParaShapeId(intAttr(xr, "ParaShape", 0));
+        header.setStyleId((short) intAttr(xr, "Style", 0));
+
+        int charPos = 0;
+        int lastCharShapeId = -1;
+        int curCharShapeId = 0;
+
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String name = xr.getLocalName();
+                if ("TEXT".equals(name)) {
+                    curCharShapeId = intAttr(xr, "CharShape", lastCharShapeId < 0 ? 0 : lastCharShapeId);
+                } else if ("CHAR".equals(name)) {
+                    String t = stripTrailingLineTerminator(readElementText(xr));
+                    if (!t.isEmpty()) {
+                        if (curCharShapeId != lastCharShapeId) {
+                            charShape.addParaCharShape(charPos, curCharShapeId);
+                            lastCharShapeId = curCharShapeId;
+                        }
+                        int i = 0;
+                        while (i < t.length()) {
+                            int cp = t.codePointAt(i);
+                            text.addNewNormalChar().setCode(cp);
+                            charPos++;
+                            i += Character.charCount(cp);
+                        }
+                    }
+                } else if ("TABLE".equals(name)) {
+                    if (curCharShapeId != lastCharShapeId) {
+                        charShape.addParaCharShape(charPos, curCharShapeId);
+                        lastCharShapeId = curCharShapeId;
+                    }
+                    addTableExtendChar(text);
+                    charPos++;
+                    readTable(para, xr);
+                } else if (SHAPE_TYPE.containsKey(name)) {
+                    if (curCharShapeId != lastCharShapeId) {
+                        charShape.addParaCharShape(charPos, curCharShapeId);
+                        lastCharShapeId = curCharShapeId;
+                    }
+                    addGsoExtendChar(text);
+                    charPos++;
+                    GsoControl gc = para.addNewGsoControl(SHAPE_TYPE.get(name));
+                    readShape(gc, name, xr);
+                } else {
+                    // 각주/숨은설명 등 그 외 컨트롤은 아직 건너뛴다.
+                    skipSubtree(xr);
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "P".equals(xr.getLocalName())) {
+                break;
+            }
+        }
+
+        // 문단 끝에 문단 구분 문자(0x0d)를 추가한다.(중복 방지)
+        text.addNewCharControlChar().setCode(0x0d);
+
+        header.setCharacterCount(text.getCharSize());
+        header.setCharShapeCount(charShape.getPositonShapeIdPairList().size());
+        header.setLineAlignCount(0);
+        return para;
+    }
+
+    /**
+     * {@code <TABLE>} 시작에 위치한 상태에서 호출. 표 컨트롤을 만들고 {@code </TABLE>}까지 읽는다.
+     * (글자 스트림의 확장 컨트롤 문자는 호출 전에 추가되어 있어야 한다 — 컨트롤과 1:1 순서 매칭)
+     */
+    private void readTable(Paragraph para, XMLStreamReader xr) throws Exception {
+        ControlTable ct = (ControlTable) para.addNewControl(ControlType.Table);
+        ct.getTable().setRowCount(intAttr(xr, "RowCount", 0));
+        ct.getTable().setColumnCount(intAttr(xr, "ColCount", 0));
+        ct.getTable().setBorderFillId(intAttr(xr, "BorderFill", 0));
+        ct.getTable().setCellSpacing(intAttr(xr, "CellSpacing", 0));
+
+        Row curRow = null;
+        Cell curCell = null;
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String name = xr.getLocalName();
+                if ("ROW".equals(name)) {
+                    curRow = ct.addNewRow();
+                } else if ("CELL".equals(name) && curRow != null) {
+                    curCell = curRow.addNewCell();
+                    setCellHeader(curCell, xr);
+                } else if ("PARALIST".equals(name) && curCell != null) {
+                    readParaList(curCell.getParagraphList(), xr);
+                } else {
+                    // SHAPEOBJECT, INSIDEMARGIN, CELLMARGIN 등은 건너뛴다.
+                    skipSubtree(xr);
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "TABLE".equals(xr.getLocalName())) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * {@code <PARALIST>} 시작에 위치한 상태에서 호출. {@code </PARALIST>}까지 문단을 읽어 container에 추가한다.
+     */
+    private void readParaList(ParagraphListInterface container, XMLStreamReader xr) throws Exception {
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                if ("P".equals(xr.getLocalName())) {
+                    readParagraph(container, xr);
+                } else {
+                    skipSubtree(xr);
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "PARALIST".equals(xr.getLocalName())) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * 그리기 개체 shape 엘리먼트 시작에 위치한 상태에서 호출. 매칭되는 종료 태그까지 읽으며
+     * 글상자 텍스트(DRAWTEXT)와 묶음(CONTAINER)의 자식 개체를 처리한다.
+     */
+    private void readShape(GsoControl gc, String shapeTag, XMLStreamReader xr) throws Exception {
+        boolean isContainer = gc instanceof ControlContainer;
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String name = xr.getLocalName();
+                if ("DRAWTEXT".equals(name)) {
+                    readDrawText(gc, xr);
+                } else if (SHAPE_TYPE.containsKey(name)) {
+                    if (isContainer) {
+                        GsoControl child = ((ControlContainer) gc).addNewChildControl(SHAPE_TYPE.get(name));
+                        readShape(child, name, xr);
+                    } else {
+                        skipSubtree(xr);
+                    }
+                }
+                // 그 외(DRAWINGOBJECT, SHAPECOMPONENT 등)는 건너뛰지 않고 그대로 진입하여
+                // 하위의 DRAWTEXT를 찾는다.
+            } else if (event == XMLStreamConstants.END_ELEMENT && shapeTag.equals(xr.getLocalName())) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * {@code <DRAWTEXT>} 시작에 위치한 상태에서 호출. 글상자 문단(PARALIST→P)을 shape의
+     * 텍스트 박스에 채운다.
+     */
+    private void readDrawText(GsoControl gc, XMLStreamReader xr) throws Exception {
+        TextBox textBox = createTextBox(gc);
+        while (xr.hasNext()) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                if ("PARALIST".equals(xr.getLocalName()) && textBox != null) {
+                    readParaList(textBox.getParagraphList(), xr);
+                } else {
+                    skipSubtree(xr);
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "DRAWTEXT".equals(xr.getLocalName())) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * 텍스트 박스를 가질 수 있는 shape이면 텍스트 박스를 생성하여 반환한다.(아니면 null)
+     */
+    private static TextBox createTextBox(GsoControl gc) {
+        if (gc instanceof ControlRectangle) {
+            ((ControlRectangle) gc).createTextBox();
+            return ((ControlRectangle) gc).getTextBox();
+        } else if (gc instanceof ControlEllipse) {
+            ((ControlEllipse) gc).createTextBox();
+            return ((ControlEllipse) gc).getTextBox();
+        } else if (gc instanceof ControlArc) {
+            ((ControlArc) gc).createTextBox();
+            return ((ControlArc) gc).getTextBox();
+        } else if (gc instanceof ControlPolygon) {
+            ((ControlPolygon) gc).createTextBox();
+            return ((ControlPolygon) gc).getTextBox();
+        } else if (gc instanceof ControlCurve) {
+            ((ControlCurve) gc).createTextBox();
+            return ((ControlCurve) gc).getTextBox();
+        }
+        return null;
+    }
+
+    /**
+     * 그리기 개체를 나타내는 확장 컨트롤 문자(code 0x0b, "gso ")를 글자 스트림에 추가한다.
+     */
+    private static void addGsoExtendChar(ParaText text) throws Exception {
+        HWPCharControlExtend ch = text.addNewExtendControlChar();
+        ch.setCode(0x000b);
+        byte[] addition = new byte[12];
+        addition[0] = ' ';
+        addition[1] = 'o';
+        addition[2] = 's';
+        addition[3] = 'g';
+        ch.setAddition(addition);
+    }
+
+    private static void setCellHeader(Cell cell, XMLStreamReader xr) {
+        ListHeaderForCell lh = cell.getListHeader();
+        lh.setColIndex(intAttr(xr, "ColAddr", 0));
+        lh.setRowIndex(intAttr(xr, "RowAddr", 0));
+        lh.setColSpan(intAttr(xr, "ColSpan", 1));
+        lh.setRowSpan(intAttr(xr, "RowSpan", 1));
+        lh.setWidth(longAttr(xr, "Width", 0));
+        lh.setHeight(longAttr(xr, "Height", 0));
+        lh.setBorderFillId(intAttr(xr, "BorderFill", 0));
+    }
+
+    /**
+     * 표를 나타내는 확장 컨트롤 문자(code 0x0b, "tbl ")를 글자 스트림에 추가한다.
+     * ({@code ParaText.addExtendCharForTable}과 달리 문단 구분 문자를 건드리지 않는다.)
+     */
+    private static void addTableExtendChar(ParaText text) throws Exception {
+        HWPCharControlExtend ch = text.addNewExtendControlChar();
+        ch.setCode(0x000b);
+        byte[] addition = new byte[12];
+        addition[0] = ' ';
+        addition[1] = 'l';
+        addition[2] = 'b';
+        addition[3] = 't';
+        ch.setAddition(addition);
+    }
+
+    /**
+     * 현재 START 엘리먼트의 텍스트 내용을 읽고 해당 END 엘리먼트까지 소비한다.
+     */
+    private static String readElementText(XMLStreamReader xr) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        int depth = 1;
+        while (xr.hasNext() && depth > 0) {
+            int event = xr.next();
+            switch (event) {
+                case XMLStreamConstants.CHARACTERS:
+                case XMLStreamConstants.CDATA:
+                    sb.append(xr.getText());
+                    break;
+                case XMLStreamConstants.START_ELEMENT:
+                    depth++;
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    depth--;
+                    break;
+                default:
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 현재 START 엘리먼트의 하위 트리 전체를 읽어 버린다(매칭되는 END까지).
+     */
+    private static void skipSubtree(XMLStreamReader xr) throws Exception {
+        int depth = 1;
+        while (xr.hasNext() && depth > 0) {
+            int event = xr.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                depth++;
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                depth--;
+            }
+        }
+    }
+
+    private static String stripTrailingLineTerminator(String s) {
+        if (s.endsWith("\r\n")) {
+            return s.substring(0, s.length() - 2);
+        }
+        if (s.endsWith("\n") || s.endsWith("\r")) {
+            return s.substring(0, s.length() - 1);
+        }
+        return s;
+    }
+
+    private static int intAttr(XMLStreamReader xr, String name, int defaultValue) {
+        String v = xr.getAttributeValue(null, name);
+        if (v == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(v.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private static long longAttr(XMLStreamReader xr, String name, long defaultValue) {
+        String v = xr.getAttributeValue(null, name);
+        if (v == null) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(v.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private static XMLStreamReader createStreamReader(InputStream is) throws Exception {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
+        // 보안: DTD / 외부 엔티티 비활성화 (XXE 방지)
+        setPropertyQuietly(factory, XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        setPropertyQuietly(factory, XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        return factory.createXMLStreamReader(is);
+    }
+
+    private static void setPropertyQuietly(XMLInputFactory factory, String name, Object value) {
+        try {
+            factory.setProperty(name, value);
+        } catch (IllegalArgumentException ignore) {
+            // 일부 구현은 해당 속성을 지원하지 않을 수 있다.
+        }
+    }
+
+    private static byte[] readAll(InputStream is) throws Exception {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                bos.write(buffer, 0, read);
+            }
+            return bos.toByteArray();
+        } finally {
+            is.close();
+        }
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/tool/hwp3conv/Hwp3ToHwpFileConverter.java
+++ b/src/main/java/kr/dogfoot/hwplib/tool/hwp3conv/Hwp3ToHwpFileConverter.java
@@ -1,0 +1,27 @@
+package kr.dogfoot.hwplib.tool.hwp3conv;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.hwp3.HWP3File;
+
+/**
+ * 한글 3.x 전용 객체 모델({@link HWP3File})을 한글 5.0 객체 모델({@link HWPFile})로
+ * 변환하는 객체.
+ *
+ * <p>변환은 best-effort이다. 3.x에만 존재하거나 5.0과 구조가 크게 다른 요소는 손실될 수
+ * 있다. 변환을 통해 기존 다운스트림 도구(텍스트 추출기 등)를 재사용할 수 있다.</p>
+ *
+ * <p>현재 P0 단계의 골격이며, 실제 변환 로직은 이후 단계(P3)에서 구현한다.</p>
+ */
+public class Hwp3ToHwpFileConverter {
+    /**
+     * 한글 3.x 객체를 한글 5.0 객체로 변환한다.
+     *
+     * @param hwp3 한글 3.x 문서 객체
+     * @return 변환된 한글 5.0 문서 객체
+     */
+    public static HWPFile convert(HWP3File hwp3) {
+        // TODO(P3): HWP3File → HWPFile (DocInfo/BodyText/Section/Paragraph) 매핑
+        throw new UnsupportedOperationException(
+                "HWP 3.x to HWPFile conversion is not implemented yet (P0 skeleton).");
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/util/hwp3/Hwp3CharDecoder.java
+++ b/src/main/java/kr/dogfoot/hwplib/util/hwp3/Hwp3CharDecoder.java
@@ -1,0 +1,72 @@
+package kr.dogfoot.hwplib.util.hwp3;
+
+/**
+ * 한글 3.x의 문자 내부 코드(hchar, 2바이트)를 유니코드 코드 포인트로 변환한다.
+ *
+ * <p>한글 3.x는 한글을 KS C 5601 <b>조합형(johab)</b> 5-5-5 비트 구조로 저장한다.
+ * 최상위 비트(0x8000)가 켜져 있으면 한글이며, 상위부터 초성(5비트)/중성(5비트)/
+ * 종성(5비트)으로 구성된다. 영문/숫자 등 ASCII는 0x0000~0x007F에 그대로 저장된다.</p>
+ *
+ * <p>한자·기호 등 그 외 2바이트 코드의 변환은 이후 단계에서 보강한다.</p>
+ */
+public class Hwp3CharDecoder {
+    /** 조합형 초성 5비트 값 → 현대 초성 인덱스(0=ㄱ … 18=ㅎ). 없으면 -1. */
+    private static final int[] CHO = new int[32];
+    /** 조합형 중성 5비트 값 → 현대 중성 인덱스(0=ㅏ … 20=ㅣ). 없으면 -1. */
+    private static final int[] JUNG = new int[32];
+    /** 조합형 종성 5비트 값 → 현대 종성 인덱스(0=없음, 1=ㄱ … 27=ㅎ). 없으면 -1. */
+    private static final int[] JONG = new int[32];
+
+    static {
+        for (int i = 0; i < 32; i++) {
+            CHO[i] = -1;
+            JUNG[i] = -1;
+            JONG[i] = -1;
+        }
+        // 초성: 값 2~20 → 0~18
+        for (int v = 2; v <= 20; v++) {
+            CHO[v] = v - 2;
+        }
+        // 중성: 비연속 매핑
+        int[] jungValues = {3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 26, 27, 28, 29};
+        for (int idx = 0; idx < jungValues.length; idx++) {
+            JUNG[jungValues[idx]] = idx;
+        }
+        // 종성: 값 1=없음, 이후 비연속(18 비어 있음)
+        int[] jongValues = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+        for (int idx = 0; idx < jongValues.length; idx++) {
+            JONG[jongValues[idx]] = idx;
+        }
+    }
+
+    /**
+     * hchar 코드를 유니코드 코드 포인트로 변환한다.
+     *
+     * @param hchar 2바이트 문자 코드
+     * @return 유니코드 코드 포인트. 변환할 수 없으면 -1.
+     */
+    public static int toCodePoint(int hchar) {
+        hchar &= 0xFFFF;
+        if ((hchar & 0x8000) != 0) {
+            int cho = CHO[(hchar >> 10) & 0x1F];
+            int jung = JUNG[(hchar >> 5) & 0x1F];
+            int jong = JONG[hchar & 0x1F];
+            if (cho >= 0 && jung >= 0 && jong >= 0) {
+                return 0xAC00 + (cho * 21 + jung) * 28 + jong;
+            }
+            return -1;
+        }
+        if (hchar < 0x80) {
+            return hchar;
+        }
+        // TODO: 한자/기호(완성형 등) 변환
+        return -1;
+    }
+
+    /**
+     * 한글(조합형) 코드인지 여부.
+     */
+    public static boolean isHangul(int hchar) {
+        return (hchar & 0x8000) != 0;
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/util/hwp3/Hwp3StreamReader.java
+++ b/src/main/java/kr/dogfoot/hwplib/util/hwp3/Hwp3StreamReader.java
@@ -1,0 +1,122 @@
+package kr.dogfoot.hwplib.util.hwp3;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.Inflater;
+
+/**
+ * 한글 3.x 바이너리 데이터를 읽기 위한 리틀 엔디언 스트림 리더.
+ *
+ * <p>규격: 「한글 문서 파일 형식 3.0 / HWPML」 revision 1.2, Part I §2(자료형).
+ * 모든 다중 바이트 값은 리틀 엔디언으로 저장된다.</p>
+ */
+public class Hwp3StreamReader {
+    private final byte[] data;
+    private int position;
+
+    public Hwp3StreamReader(byte[] data) {
+        this(data, 0);
+    }
+
+    public Hwp3StreamReader(byte[] data, int position) {
+        this.data = data;
+        this.position = position;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public int remaining() {
+        return data.length - position;
+    }
+
+    public boolean isEndOfStream() {
+        return position >= data.length;
+    }
+
+    /**
+     * 부호 없는 1바이트(byte)를 읽는다.
+     */
+    public int readUInt8() {
+        return data[position++] & 0xFF;
+    }
+
+    /**
+     * 부호 있는 1바이트(sbyte)를 읽는다.
+     */
+    public int readInt8() {
+        return data[position++];
+    }
+
+    /**
+     * 부호 없는 2바이트(word)를 읽는다.
+     */
+    public int readUInt16() {
+        int v = (data[position] & 0xFF) | ((data[position + 1] & 0xFF) << 8);
+        position += 2;
+        return v;
+    }
+
+    /**
+     * 부호 있는 2바이트(sword)를 읽는다.
+     */
+    public short readInt16() {
+        return (short) readUInt16();
+    }
+
+    /**
+     * 부호 없는 4바이트(dword)를 읽는다.
+     */
+    public long readUInt32() {
+        long v = (data[position] & 0xFFL)
+                | ((data[position + 1] & 0xFFL) << 8)
+                | ((data[position + 2] & 0xFFL) << 16)
+                | ((data[position + 3] & 0xFFL) << 24);
+        position += 4;
+        return v;
+    }
+
+    public byte[] readBytes(int n) {
+        byte[] r = new byte[n];
+        System.arraycopy(data, position, r, 0, n);
+        position += n;
+        return r;
+    }
+
+    public void skip(int n) {
+        position += n;
+    }
+
+    /**
+     * raw DEFLATE(zlib/gzip 헤더 없는 압축)로 압축된 데이터를 해제한다.
+     * 한글 3.x의 압축 영역은 이 방식으로 저장된다.
+     *
+     * @param input  전체 바이트
+     * @param offset 압축 영역 시작 오프셋
+     * @return 해제된 바이트
+     */
+    public static byte[] inflateRaw(byte[] input, int offset) throws Exception {
+        Inflater inflater = new Inflater(true);
+        inflater.setInput(input, offset, input.length - offset);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(Math.max(1024, (input.length - offset) * 4));
+        byte[] buffer = new byte[65536];
+        try {
+            while (!inflater.finished()) {
+                int n = inflater.inflate(buffer);
+                if (n == 0) {
+                    if (inflater.needsInput() || inflater.needsDictionary()) {
+                        break;
+                    }
+                }
+                bos.write(buffer, 0, n);
+            }
+        } finally {
+            inflater.end();
+        }
+        return bos.toByteArray();
+    }
+}

--- a/src/main/java/kr/dogfoot/hwplib/writer/autosetter/ForDocInfo.java
+++ b/src/main/java/kr/dogfoot/hwplib/writer/autosetter/ForDocInfo.java
@@ -1,6 +1,5 @@
 package kr.dogfoot.hwplib.writer.autosetter;
 
-import com.sun.jmx.snmp.agent.SnmpUserDataFactory;
 import kr.dogfoot.hwplib.object.bodytext.BodyText;
 import kr.dogfoot.hwplib.object.docinfo.DocInfo;
 import kr.dogfoot.hwplib.object.docinfo.DocumentProperties;

--- a/src/test/sample/Detecting_FileFormat.java
+++ b/src/test/sample/Detecting_FileFormat.java
@@ -1,0 +1,51 @@
+package sample;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.reader.FileFormat;
+import kr.dogfoot.hwplib.reader.HWPLibReader;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+/**
+ * 파일 형식 자동 판별 및 통합 리더 사용 예제.
+ *
+ * <p>한글 5.0 / 한글 3.x / HWPML을 자동으로 판별하여 공통 객체 모델({@link HWPFile})로
+ * 읽는다. (한글 3.x · HWPML 본문 파싱은 이후 단계에서 구현 예정 — P0 골격)</p>
+ */
+public class Detecting_FileFormat {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.out.println("usage: Detecting_FileFormat <file>");
+            return;
+        }
+
+        byte[] data = readAll(new FileInputStream(args[0]));
+
+        FileFormat format = HWPLibReader.detectFormat(data);
+        System.out.println("Detected format: " + format);
+
+        try {
+            HWPFile hwpFile = HWPLibReader.fromBytes(data);
+            System.out.println("Read OK. sections="
+                    + hwpFile.getBodyText().getSectionList().size());
+        } catch (UnsupportedOperationException e) {
+            System.out.println("Not yet implemented: " + e.getMessage());
+        }
+    }
+
+    private static byte[] readAll(InputStream is) throws Exception {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                bos.write(buffer, 0, read);
+            }
+            return bos.toByteArray();
+        } finally {
+            is.close();
+        }
+    }
+}

--- a/src/test/sample/Reading_HWPML.java
+++ b/src/test/sample/Reading_HWPML.java
@@ -1,0 +1,32 @@
+package sample;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.bodytext.Section;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
+import kr.dogfoot.hwplib.reader.hwpml.HWPMLReader;
+
+/**
+ * HWPML(.hml) 파일을 읽어 본문 문단 텍스트를 출력하는 예제.
+ *
+ * <p>현재 구현 범위(M1): 본문 구역의 문단/글자만 매핑한다. 표/그림/각주 등 컨트롤
+ * 내부 텍스트와 글꼴·서식(DocInfo)은 이후 단계에서 추가된다.</p>
+ */
+public class Reading_HWPML {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.out.println("usage: Reading_HWPML <file.hml>");
+            return;
+        }
+
+        HWPFile hwpFile = HWPMLReader.fromFile(args[0]);
+
+        for (Section section : hwpFile.getBodyText().getSectionList()) {
+            for (Paragraph paragraph : section.getParagraphs()) {
+                String text = paragraph.getNormalString();
+                if (text != null) {
+                    System.out.println(text);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
기존 HWP5 경로는 손대지 않는 순수 추가 방식.

JDK 베이스 7 → 17 전환:
- pom: source/target 17 (deprecated compilerVersion 제거)
- HWPReader: javax.xml.bind.DatatypeConverter → java.util.Base64
- ForDocInfo: 미사용 com.sun.jmx.snmp.agent 임포트 제거

포맷 자동 판별(P0):
- FileFormat 열거형 + FormatDetector(OLE/HWP3 sig/XML, BOM·UTF-16)
- HWPLibReader 통합 진입점 → 판별 후 라우팅, 공통 HWPFile 반환

HWPML 3.0 리더(P1, 텍스트 추출 사실상 완결):
- HWPMLReader(StAX 재귀 하강) + ForHead(HEAD→DocInfo)
- 본문 문단/글자(M1) + 글꼴/글자모양/문단모양/스타일/번호(M2)
- 표(ControlTable) + 그리기 개체/글상자(GSO TextBox, M3)
- 검증: 동일 문서 6종에서 HWP5 추출 대비 텍스트 ≥99.9%(3종 100%)

HWP 3.x 레거시 바이너리 리더(P2):
- Hwp3StreamReader(리틀엔디언 + raw DEFLATE 해제)
- HWP3Reader C1: 헤더/압축/섹션(글꼴·스타일) 구조 파싱
- Hwp3CharDecoder C2: hchar→유니코드(조합형 5-5-5), 실문서 검증
- C3(문단/특수문자 순회)·C6(HWPFile 변환)는 잔여

상세 계획·진행 상황: docs/hwp3-hwpml-support-plan.md
(검증용 코퍼스·규격 PDF는 .gitignore로 로컬 유지)